### PR TITLE
#63: Add aspect ratio support to the resize directive

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -19,6 +19,7 @@
 - [Quality](#quality)
 - [Width](#width)
 - [Height](#height)
+- [Aspect](#aspect)
 - [Rotate](#rotate)
 - [Tint](#tint)
 
@@ -311,6 +312,28 @@ If not given the width will be scaled accordingly.
 import Image from 'example.jpg?height=200'
 import Image from 'examepl.jpg?h=200'
 import Images from 'examepl.jpg?height=200;400;700'
+```
+
+___
+
+### Aspect
+• **Keyword**: `aspect`<br>
+• **Type**: _string_<br>
+
+
+Resizes the image to be the specified aspect ratio.
+If height and width are both provided, this will be ignored.
+If height is provided, the width will be scaled accordingly.
+If width is provided, the width will be scaled accordingly.
+If neither height nor width are provided, the image will be cropped to the given aspect ratio.
+
+
+• **Example**:  
+```js
+import Image from 'example.jpg?aspect=16:9'
+import Image from 'example.jpg?aspect=16:9&height=200'
+import Image from 'example.jpg?aspect=16:9&width=200'
+import Images from 'example.jpg?aspect=16:9&h=200;400;700'
 ```
 
 ___

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-basic-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-basic-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd65fa47fb2e534df9baf4b6c929babf02023ded94438daf331a612c36960b00
+size 19354

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-&-background-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-&-background-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00bddd2f478d30358f187b82f0d9b6cba01d10aee409159389000215d6ded001
+size 12103

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20db672e09fffdcd001e3ff7aba92eb72d858d07889e5c6994f1e9a8bd5d1833
+size 12138

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-and-position-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--fit-and-position-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:613debb7c58f7ead0e652755682ada17cc67e59081481cb2211cf23f89807eb8
+size 22075

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--height-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--height-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8574b9909965eb487cd194c273daed0f07fa123a48b64b039b455a727c0351c2
+size 1181

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--kernel-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--kernel-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd65fa47fb2e534df9baf4b6c929babf02023ded94438daf331a612c36960b00
+size 19354

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--width-&-height-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--width-&-height-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca38665082f2d83977614db3dcd28632113422da3042f7ab8039f2acdb4f1a92
+size 6201

--- a/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--width-0
+++ b/packages/core/src/transforms/__tests__/__file_snapshots__/aspect-transform-w--width-0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd3ff0ce9b23b1e6cbbab76618ee2db388533bd1ec3fa60bba771b912a6fe696
+size 5202

--- a/packages/core/src/transforms/__tests__/resize.spec.ts
+++ b/packages/core/src/transforms/__tests__/resize.spec.ts
@@ -223,3 +223,105 @@ describe('width & height', () => {
         })
     })
 })
+
+describe('aspect', () => {
+    let dirCtx: TransformFactoryContext
+    beforeAll(() => {
+        dirCtx = { useParam: jest.fn, warn: jest.fn }
+    })
+
+    test('keyword "aspect"', () => {
+        const res = resize({ aspect: '16:9' }, dirCtx)
+
+        expect(res).toBeInstanceOf(Function)
+    })
+
+    test('missing', () => {
+        const res = resize({}, dirCtx)
+
+        expect(res).toBeUndefined()
+    })
+
+    describe('arguments', () => {
+        test('invalid', () => {
+            const res = resize({ aspect: 'invalid' }, dirCtx)
+
+            expect(res).toBeUndefined()
+        })
+
+        test('empty', () => {
+            const res = resize({ aspect: '' }, dirCtx)
+
+            expect(res).toBeUndefined()
+        })
+
+        test('colon delimited aspect ratio', () => {
+            const res = resize({ height: '16:9' }, dirCtx)
+
+            expect(res).toBeInstanceOf(Function)
+        })
+    })
+
+    describe('transform', () => {
+        let img: Sharp
+        beforeEach(() => {
+            img = sharp(join(__dirname, '../../__tests__/__assets__/pexels-allec-gomes-5195763.jpg'))
+        })
+
+        test('basic', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ fit', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', fit: 'contain' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ fit & background', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', fit: 'contain', background: '0f0' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ fit and position', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', fit: 'cover', position: 'top' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ kernel', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', kernel: 'cubic' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ height', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', height: '75' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ width', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', width: '300' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+
+        test('w/ width & height', async () => {
+            //@ts-ignore
+            const { image, metadata } = await applyTransforms([resize({ aspect: '4:3', height: '300', width: '300' }, dirCtx)], img)
+
+            expect(await image.toBuffer()).toMatchFile()
+        })
+    })
+})

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -4,7 +4,6 @@ import { getPosition } from './position'
 import { getKernel } from './kernel'
 import { getBackground } from './background'
 import { setMetadata, getMetadata } from "../lib/metadata";
-import { Sharp } from "sharp";
 
 export interface ResizeOptions {
     width: string
@@ -81,6 +80,7 @@ export const resize: TransformFactory<ResizeOptions> = (config, ctx) => {
 
         setMetadata(image, 'height', finalHeight)
         setMetadata(image, 'width', finalWidth)
+        setMetadata(image, 'aspect', aspect || metaAspect)
 
         return image.resize({
             width: finalWidth,

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -4,12 +4,33 @@ import { getPosition } from './position'
 import { getKernel } from './kernel'
 import { getBackground } from './background'
 import { setMetadata, getMetadata } from "../lib/metadata";
+import { Sharp } from "sharp";
 
 export interface ResizeOptions {
     width: string
     w: string
     height: string
     h: string
+    aspect: string
+}
+
+function parseAspect(aspect?: string) {
+    if (!aspect || !aspect.split) {
+        return undefined;
+    }
+
+    const [width, height] = aspect.split(':')
+
+    if (!width || !height) {
+        return undefined
+    }
+
+    const widthInt = parseInt(width)
+    const heightInt = parseInt(height)
+
+    return widthInt && heightInt && widthInt > 0 && heightInt > 0
+        ? widthInt / heightInt
+        : undefined
 }
 
 export const resize: TransformFactory<ResizeOptions> = (config, ctx) => {
@@ -24,28 +45,46 @@ export const resize: TransformFactory<ResizeOptions> = (config, ctx) => {
         : config.h
             ? parseInt(config.h)
             : undefined
+    const aspect = width && height
+        ? width / height
+        : parseAspect(config.aspect)
 
-    if (!width && !height) return
+    if (!width && !height && !aspect) return
 
     return function resizeTransform(image) {
+        let finalWidth = width
+        let finalHeight = height
 
-        if (!height) {
-            const w = getMetadata(image, 'width')
-            const h = getMetadata(image, 'height')
-            setMetadata(image, 'height', Math.round((width! / w) * h))
-            setMetadata(image, 'width', width)
+        const w = getMetadata(image, 'width')
+        const h = getMetadata(image, 'height')
+
+        const metaAspect = w / h
+
+        if (width && height) {
+            /* both dimensions were provided, aspect is ignored and no calculations are needed */
+        }
+        else if (!height && !width) {
+            /* only aspect was given, need to calculate which dimension to crop */
+            const useWidth = aspect! > metaAspect
+
+            finalHeight = useWidth ? Math.round(w / aspect!) : h
+            finalWidth = useWidth ? w : Math.round(h / aspect!)
+        } else if (!height) {
+            /* only width was provided, need to calculate height */
+            finalHeight = width! / (aspect || metaAspect)
+            finalWidth = width
+        } else {
+            /* only height was provided, need to calculate width */
+            finalHeight = height
+            finalWidth = height * (aspect || metaAspect)
         }
 
-        if (!width) {
-            const w = getMetadata(image, 'width')
-            const h = getMetadata(image, 'height')
-            setMetadata(image, 'width', Math.round((height! / h) * w))
-            setMetadata(image, 'height', height)
-        }
+        setMetadata(image, 'height', finalHeight)
+        setMetadata(image, 'width', finalWidth)
 
         return image.resize({
-            width: width,
-            height: height,
+            width: finalWidth,
+            height: finalHeight,
             fit: getFit(config, image),
             position: getPosition(config, image),
             kernel: getKernel(config, image),


### PR DESCRIPTION
[Add aspect ratio support to the resize directive](https://github.com/JonasKruckenberg/imagetools/issues/63)

This change adds an `aspect` keyword used in the resize transform.

Use Cases:
- If aspect & width are provided, calculate height to match
- If aspect & height are provided, calculate width to match
- If only aspect is provided, calculate both height and width.  This will keep the the original image as large as possible, meaning only one dimension will be cropped to get the correct aspect ratio
- If height & width are both provided, ignore the `aspect` keyword

**Tests**
Test coverage added to the `core` package, covering the cases above as well as combinations with fit, background, position, and kernel