### PR TITLE
feat: Add ability to override resolveConfigs in vite plugin

### DIFF
--- a/.changeset/resolve-configs.md
+++ b/.changeset/resolve-configs.md
@@ -1,7 +1,6 @@
 ---
-'imagetools-core': patch
-'rollup-plugin-imagetools': patch
-'vite-imagetools': patch
+'rollup-plugin-imagetools': minor
+'vite-imagetools': minor
 ---
 
 feat: allow override of resolveConfigs

--- a/.changeset/resolve-configs.md
+++ b/.changeset/resolve-configs.md
@@ -1,0 +1,7 @@
+---
+'imagetools-core': patch
+'rollup-plugin-imagetools': patch
+'vite-imagetools': patch
+---
+
+feat: allow override of resolveConfigs

--- a/docs/guide/extending.md
+++ b/docs/guide/extending.md
@@ -118,6 +118,9 @@ Sometimes it's useful to be able to override the resolution of image configs at 
 to implement presets using shortnames that generate multiple images. This resolution is done before the config
 is passed to the directives. To implement a custom scheme, pass a function as `resolveConfigs` plugin options.
 
+The function should return a new config array. If a plugin needs to modify the config that would have been used,
+it can call the default `resolveConfigs` function which is part of the public API.
+
 Below is an example custom `resolveConfigs` to implement site preset widths which are always webp format.
 
 ```ts

--- a/docs/guide/extending.md
+++ b/docs/guide/extending.md
@@ -111,3 +111,63 @@ function customDirective(): ImageTransform {
 ## Custom Output Formats
 
 _TODO_
+
+## Custom config resolution
+
+Sometimes it's useful to be able to override the resolution of image configs at a low level, for example
+to implement presets using shortnames that generate multiple images. This resolution is done before the config
+is passed to the directives. To implement a custom scheme, pass a function as `resolveConfigs` plugin options.
+
+Below is an example custom `resolveConfigs` to implement site preset widths which are always webp format.
+
+```ts
+const defaultPresets = {
+  default: {widths: [300, 800, 1200]}
+}
+
+export function resolveConfigsWithPresets(pluginConfig) {
+    // use provided presets or use defaults above 
+    const presets = pluginConfig?.presets || defaultPresets
+
+    // this is the custom resolveConfigs function 
+    return function (config) {
+        // look for 'mysite' in the import name
+        const mysite_config = config.find(([key]) => key === "mysite")
+        if (mysite_config) {
+            // get the preset if specified
+            const [, [value]] = mysite_config
+            // see if there is a custom preset specified, eg: mysite=mypreset, or use default
+            const preset_name = value.trim().length ? value.trim() : "default"
+            // fall back to default preset if one given doesn't exist
+            const preset = presets[preset_name] || defaultPresets.default
+
+            // map preset widths to 
+            const widths = preset.widths
+            return widths.map((width, index) => ({
+                width,
+                webp: ""
+            }));
+        }
+        // else return undefined and default resolveConfigs will be called
+    }
+}
+```
+
+```
+// vite.config.js, etc
+...
+    plugins: [
+      react(),
+      imagetools({
+        resolveConfigs: resolveConfigsWithPresets({ 
+            mypreset: {widths: [100,200,300]} 
+        })
+      })
+    ]
+...
+```
+
+```
+// page.tsx, etc
+import img_urls from "./myimage.png?mypreset"
+```

--- a/packages/rollup/src/__tests__/main.test.ts
+++ b/packages/rollup/src/__tests__/main.test.ts
@@ -1,4 +1,4 @@
-import { OutputAsset, OutputChunk, rollup } from 'rollup'
+import { OutputAsset, OutputChunk, rollup, RollupOutput } from 'rollup'
 import { imagetools } from '../index'
 import { join } from 'path'
 import { testEntry, getFiles } from './util'
@@ -196,6 +196,31 @@ describe('rollup-plugin-imagetools', () => {
         expect(metadata).toHaveProperty('icc')
         expect(metadata).toHaveProperty('xmp')
       })
+
+      describe('resolveConfigs', () => {
+        test('can be used to generate multiple images (presets)', async () => {
+          const bundle = await rollup({
+            plugins: [
+              testEntry(`
+                            import Image from "./with-metadata.png?w=300"
+                            export default Image
+                        `),
+              imagetools({
+                resolveConfigs() {
+                  return [
+                    { width: '300' },
+                    { width: '500' }
+                  ]
+                }
+              })
+            ]
+          })
+
+          const files = (await getFiles(bundle, '**.png')) as OutputAsset[]
+          expect(files).toHaveLength(2)
+        })
+      })
+
     })
   })
 

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -46,7 +46,7 @@ export function imagetools(userOptions: Partial<PluginOptions> = {}): Plugin {
 
       const srcURL = parseURL(id)
       const parameters = extractEntries(srcURL)
-      const imageConfigs = resolveConfigs(parameters, outputFormats)
+      const imageConfigs = pluginOptions.resolveConfigs?.(parameters, outputFormats) || resolveConfigs(parameters, outputFormats)
 
       const img = loadImage(decodeURIComponent(srcURL.pathname))
 

--- a/packages/rollup/src/types.ts
+++ b/packages/rollup/src/types.ts
@@ -1,4 +1,4 @@
-import { TransformFactory, OutputFormat } from 'imagetools-core'
+import { TransformFactory, OutputFormat, resolveConfigs } from 'imagetools-core'
 
 export interface PluginOptions {
   /**
@@ -31,6 +31,12 @@ export interface PluginOptions {
    * @default []
    */
   extendOutputFormats?: (builtins: Record<string, OutputFormat>) => Record<string, OutputFormat>
+
+  /**
+   * You can use this option to override the resolution of configs based on the url parameters
+   * @default undefined
+   */
+  resolveConfigs?: typeof resolveConfigs
 
   /**
    * Settings this option to true disables all warnings produced by this plugin

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -199,9 +199,12 @@ describe('vite-imagetools', () => {
     })
 
     describe('silent', () => {
-      test('false by default', () => {})
-      test('true disables all warnings', () => {})
-      test('false enables warnings', () => {})
+      test('false by default', () => {
+      })
+      test('true disables all warnings', () => {
+      })
+      test('false enables warnings', () => {
+      })
     })
 
     describe('removeMetadata', () => {
@@ -249,6 +252,32 @@ describe('vite-imagetools', () => {
 
         expect(metadata).toHaveProperty('icc')
         expect(metadata).toHaveProperty('xmp')
+      })
+    })
+
+    describe('resolveConfigs', () => {
+      test('can be used to generate multiple images (presets)', async () => {
+        const bundle = (await build({
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./with-metadata.png?metadata"
+                            window.__IMAGE__ = Image
+                        `),
+            imagetools({
+              resolveConfigs() {
+                return [
+                  { width: '300' },
+                  { width: '500' }
+                ]
+              }
+            })
+          ]
+        })) as RollupOutput | RollupOutput[]
+
+        const files = getFiles(bundle, '**.png') as OutputAsset[]
+        expect(files).toHaveLength(2)
       })
     })
   })

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -50,7 +50,7 @@ export function imagetools(userOptions: Partial<PluginOptions> = {}): Plugin {
 
       const srcURL = parseURL(id)
       const parameters = extractEntries(srcURL)
-      const imageConfigs = resolveConfigs(parameters, outputFormats)
+      const imageConfigs = pluginOptions.resolveConfigs?.(parameters, outputFormats) || resolveConfigs(parameters, outputFormats)
 
       const img = loadImage(decodeURIComponent(srcURL.pathname))
 

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -33,6 +33,10 @@ export interface PluginOptions {
    */
   extendOutputFormats?: (builtins: Record<string, OutputFormat>) => Record<string, OutputFormat>
 
+  /**
+   * You can use this option to override the resolution of configs based on the url parameters
+   * @default undefined
+   */
   resolveConfigs?: typeof resolveConfigs
 
   /**

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -1,4 +1,4 @@
-import { TransformFactory, OutputFormat } from 'imagetools-core'
+import { TransformFactory, OutputFormat, resolveConfigs } from 'imagetools-core'
 
 export interface PluginOptions {
   /**
@@ -32,6 +32,8 @@ export interface PluginOptions {
    * @default []
    */
   extendOutputFormats?: (builtins: Record<string, OutputFormat>) => Record<string, OutputFormat>
+
+  resolveConfigs?: typeof resolveConfigs
 
   /**
    * Settings this option to true disables all warnings produced by this plugin


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This pull request relates to #139. It adds ability to supply a custom `resolveConfigs`.

- **What is the new behavior (if this is a feature change)?**

If you don't set property in config everything works the same as before. You can supply a function that will be called in place of the default `resolveConfigs`. If this function doesn't return a value, the existing `resolveConfigs` is called, otherwise the result of the custom `resolveConfigs` is used.

Below is an example of a custom implementation. If you add `?glowsite=<preset>` to an image import it will generate images with preset widths in webp format.

```
const defaultPresets = {
    default: {widths: [300, 800, 1200]}
}

export function glowsiteImageToolsPresets(pluginConfig) {
    const presets = pluginConfig?.presets || defaultPresets

    return function (config) {
        const glowsite_config = config.find(([key]) => key === "glowsite")
        if (glowsite_config) {
            const [, [value]] = glowsite_config
            const preset_name = value.trim().length ? value.trim() : "default"
            const preset = presets[preset_name] || defaultPresets.default
            const widths = preset.widths

            return widths.map(width => ({
                width,
                webp: ""
            }))
        }
    }
}
```

```
// vite.config.js
...
export default {
    plugins: [
        react(),
        imagetools({
            resolveConfigs: glowsiteImageToolsPresets({default: {widths: [100,200,300]}})
        }),
...
```

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

No (intentional) breaking changes.

- **Other information**:

If you think this PR might be accepted I can add tests, docs, changeset, etc.

I had trouble running the tests on Windows (and on Ubuntu actually) after clean checkout of your repo, so might need some help resolving that before I can add tests.

^--- issue on Ubuntu is probably git-lfs issue (similar to #210) in which case I can workaround Windows issue