### PR TITLE
fix: clone image in vite plugin to avoid dev server issue (#140)

### DIFF
--- a/.changeset/fix140.md
+++ b/.changeset/fix140.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: clone sharp image in vite plugin to avoid reuse issue

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -65,7 +65,7 @@ export function imagetools(userOptions: Partial<PluginOptions> = {}): Plugin {
             : pluginOptions.defaultDirectives
 
         const { transforms } = generateTransforms({ ...defaultConfig, ...config }, transformFactories)
-        const { image, metadata } = await applyTransforms(transforms, img, pluginOptions.removeMetadata)
+        const { image, metadata } = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)
 
         generatedImages.set(id, image)
 


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes #140 

- **What is the new behavior (if this is a feature change)?**

None

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

No

- **Other information**:

Am not sure if cloning an image has performance implications. Perhaps could be optimised by only cloning if there is more than one image format in the array, but didn't see worth premature optimisation.