### PR TITLE
Fix path to typings

### DIFF
--- a/.changeset/tasty-crews-allow.md
+++ b/.changeset/tasty-crews-allow.md
@@ -1,0 +1,6 @@
+---
+"vite-imagetools": patch
+"rollup-plugin-imagetools": patch
+---
+
+Fix path to typings

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "dist/rollup/src/index.d.ts",
   "license": "MIT",
   "files": [
     "dist"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,7 @@
   "version": "3.9.0",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "dist/vite/src/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes the error "Cannot find module 'vite-imagetools' or its corresponding type declarations."