### PR TITLE
fix(doc): use semicolon instead of comma

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -267,7 +267,7 @@ The argument must be a number between 0 and 100.
 ```js
 import Image from 'example.jpg?format=webp&quality=100'
 import Image from 'example.jpg?png&quality=200'
-import Images from 'example.jpg?avif&quality=10,50,75'
+import Images from 'example.jpg?avif&quality=10;50;75'
 ```
 
 ---


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update

- **What is the new behavior (if this is a feature change)?**
Nothing

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

- **Other information**:
/
---

The current example doesn't work:
```js
import Images from 'example.jpg?avif&quality=10,50,75'
```
Use semicolons instead:
```js
import Images from 'example.jpg?avif&quality=10;50;75'
```