### PR TITLE
fix: let vite create final paths

### DIFF
--- a/.changeset/two-games-kiss.md
+++ b/.changeset/two-games-kiss.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+Let vite create correct paths in build result

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -14,7 +14,6 @@ import {
 } from 'imagetools-core'
 import { basename, extname, posix } from 'path'
 import { createFilter, dataToEsm } from '@rollup/pluginutils'
-import MagicString from 'magic-string'
 import { VitePluginOptions } from './types'
 
 const defaultOptions: VitePluginOptions = {
@@ -52,7 +51,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
       let directives = srcURL.searchParams
 
-      if(typeof pluginOptions.defaultDirectives === "function") {
+      if (typeof pluginOptions.defaultDirectives === 'function') {
         directives = new URLSearchParams([...pluginOptions.defaultDirectives(srcURL), ...srcURL.searchParams])
       } else if (pluginOptions.defaultDirectives) {
         directives = new URLSearchParams([...pluginOptions.defaultDirectives, ...srcURL.searchParams])
@@ -83,7 +82,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             type: 'asset'
           })
 
-          metadata.src = `__VITE_IMAGE_ASSET__${fileHandle}__`
+          metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
           metadata.src = posix.join('/@imagetools', id)
         }
@@ -134,32 +133,6 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
         next()
       })
-    },
-
-    renderChunk(code) {
-      const assetUrlRE = /__VITE_IMAGE_ASSET__([a-z\d]{8})__(?:_(.*?)__)?/g
-
-      let match
-      let s
-      while ((match = assetUrlRE.exec(code))) {
-        s = s || (s = new MagicString(code))
-        const [full, hash, postfix = ''] = match
-
-        const file = this.getFileName(hash)
-
-        const outputFilepath = viteConfig.base + file + postfix
-
-        s.overwrite(match.index, match.index + full.length, outputFilepath)
-      }
-
-      if (s) {
-        return {
-          code: s.toString(),
-          map: viteConfig.build.sourcemap ? s.generateMap({ hires: true }) : null
-        }
-      } else {
-        return null
-      }
     }
   }
 }


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [n/a] I have written new tests, as applicable (for bug fixes / features)
* [n/a] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes the paths of images in the Vite build result. Before the filename was added to `viteConfig.base` which leads to relative urls that don't work anymore in nested paths.

- **What is the new behavior (if this is a feature change)?**
Instead of inserting the final path in imagetools, the existing placeholder logic from Vite is used and Vite will do the replacement.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

- **Other information**:
