### PR TITLE
fix: revert bundling of imagetools-core

### DIFF
--- a/.changeset/new-parents-appear.md
+++ b/.changeset/new-parents-appear.md
@@ -1,0 +1,6 @@
+---
+'rollup-plugin-imagetools': patch
+'vite-imagetools': patch
+---
+
+fix: revert bundling of imagetools-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,11 +91,11 @@ jobs:
         with:
           run_install: true
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@master
+      - name: create and publish versions
+        uses: changesets/action@v1
         with:
-          publish: pnpm -w run release
+          version: pnpm changeset version && pnpm doc
+          publish: pnpm build && pnpm publish -r
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "release": "pnpm run build && pnpm changeset publish",
     "build": "pnpm run --recursive --filter !example-* build",
     "test": "pnpm run --recursive test",
     "coverage": "pnpm run --recursive coverage",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-imagetools",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "types": "dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.0",
+    "imagetools-core": "workspace:^",
     "magic-string": "^0.27.0"
   },
   "devDependencies": {
@@ -44,7 +45,6 @@
     "@types/picomatch": "^2.3.0",
     "@types/sharp": "^0.31.0",
     "@vitest/coverage-c8": "^0.25.0",
-    "imagetools-core": "workspace:^",
     "jest-image-snapshot": "^6.0.0",
     "jsdom": "^20.0.0",
     "picomatch": "^2.3.1",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-imagetools",
   "description": "Load and transform images using a toolbox of import directives!",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "types": "dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
@@ -38,7 +38,8 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@rollup/pluginutils": "^5.0.0"
+    "@rollup/pluginutils": "^5.0.0",
+    "imagetools-core": "workspace:^"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^10.0.0",
@@ -47,7 +48,6 @@
     "@types/picomatch": "^2.3.0",
     "@types/sharp": "^0.31.0",
     "@vitest/coverage-c8": "^0.25.0",
-    "imagetools-core": "workspace:^",
     "jest-image-snapshot": "^6.0.0",
     "jsdom": "^20.0.0",
     "picomatch": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,7 @@ importers:
       vitest: ^0.25.0
     dependencies:
       '@rollup/pluginutils': 5.0.0_rollup@3.2.3
+      imagetools-core: link:../core
       magic-string: 0.27.0
     devDependencies:
       '@rollup/plugin-typescript': 10.0.0_bvn3ed5hy3sfde644tygjdj4ia
@@ -96,7 +97,6 @@ importers:
       '@types/picomatch': 2.3.0
       '@types/sharp': 0.31.0
       '@vitest/coverage-c8': 0.25.0_jsdom@20.0.0
-      imagetools-core: link:../core
       jest-image-snapshot: 6.0.0
       jsdom: 20.0.0
       picomatch: 2.3.1
@@ -127,6 +127,7 @@ importers:
       vitest: ^0.25.0
     dependencies:
       '@rollup/pluginutils': 5.0.0_rollup@3.2.3
+      imagetools-core: link:../core
     devDependencies:
       '@rollup/plugin-typescript': 10.0.0_bvn3ed5hy3sfde644tygjdj4ia
       '@types/jest-image-snapshot': 6.1.0
@@ -134,7 +135,6 @@ importers:
       '@types/picomatch': 2.3.0
       '@types/sharp': 0.31.0
       '@vitest/coverage-c8': 0.25.0_jsdom@20.0.0
-      imagetools-core: link:../core
       jest-image-snapshot: 6.0.0
       jsdom: 20.0.0
       picomatch: 2.3.1


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [X] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** Fix

- **What is the new behavior (if this is a feature change)?** Don't bundle `imagetools-core`

- **Does this PR introduce a breaking change?** Just reverts to previous behavior

- **Other information**: Apparently rollup doesn't bundle types, which makes bundling the core library in not work all that well
