### PR TITLE
feat: add withoutEnlargment + withoutReduction

### DIFF
--- a/.changeset/six-cougars-grin.md
+++ b/.changeset/six-cougars-grin.md
@@ -1,0 +1,5 @@
+---
+"imagetools-core": minor
+---
+
+Add `withoutEnlargment` & `withoutReduction` directives to prevent images being enlarged or shrunk beyond der original size.

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,27 +1,37 @@
 ## Table of Contents
 
-- [Background](#background)
-- [Blur](#blur)
-- [Fit](#fit)
-- [Flatten](#flatten)
-- [Flip](#flip)
-- [Flop](#flop)
-- [Format](#format)
-- [Grayscale](#grayscale)
-- [Hue](#hue)
-- [Saturation](#saturation)
-- [Brightness](#brightness)
-- [Invert](#invert)
-- [Kernel](#kernel)
-- [Median](#median)
-- [Normalize](#normalize)
-- [Position](#position)
-- [Quality](#quality)
-- [Width](#width)
-- [Height](#height)
-- [Aspect](#aspect)
-- [Rotate](#rotate)
-- [Tint](#tint)
+- [Table of Contents](#table-of-contents)
+  - [Output Directives](#output-directives)
+- [Directives](#directives)
+  - [Background](#background)
+  - [Blur](#blur)
+  - [Fit](#fit)
+  - [Flatten](#flatten)
+  - [Flip](#flip)
+  - [Flop](#flop)
+  - [Format](#format)
+  - [Grayscale](#grayscale)
+  - [Hue](#hue)
+  - [Saturation](#saturation)
+  - [Brightness](#brightness)
+  - [Invert](#invert)
+  - [Kernel](#kernel)
+  - [Median](#median)
+  - [Normalize](#normalize)
+  - [Position](#position)
+  - [Quality](#quality)
+  - [Width](#width)
+  - [Height](#height)
+  - [Aspect](#aspect)
+  - [Without Enlargement](#without-enlargement)
+  - [Without Reduction](#without-reduction)
+  - [Rotate](#rotate)
+  - [Tint](#tint)
+  - [Metadata](#metadata)
+  - [Picture](#picture)
+  - [Source](#source)
+  - [Srcset](#srcset)
+  - [URL](#url)
 
 ### Output Directives
 
@@ -331,6 +341,38 @@ import Image from 'example.jpg?aspect=16:9'
 import Image from 'example.jpg?aspect=16:9&height=200'
 import Image from 'example.jpg?aspect=16:9&width=200'
 import Images from 'example.jpg?aspect=16:9&h=200;400;700'
+```
+
+---
+
+### Without Enlargement
+
+• **Keyword**: `withoutEnlargement`<br> • **Type**: _boolean_<br>
+
+Prevents the image from being resized if the specified or calculated width or height are greater than the original width or height.
+
+• **Example**:
+
+```js
+import Image from 'example.jpg?width=200;400&withoutEnlargement'
+import Image from 'example.jpg?aspect=16:9&withoutEnlargement'
+import Images from 'example.jpg?aspect=16:9&h=200;400;700&withoutEnlargement'
+```
+
+---
+
+### Without Reduction
+
+• **Keyword**: `withoutReduction`<br> • **Type**: _boolean_<br>
+
+Prevents the image from being resized if the specified or calculated width or height are less than the original width or height.
+
+• **Example**:
+
+```js
+import Image from 'example.jpg?height=300;600;900&withoutReduction'
+import Image from 'example.jpg?aspect=9:16&withoutReduction'
+import Images from 'example.jpg?aspect=16:9&h=200;400;700&withoutEnlargement&withoutReduction'
 ```
 
 ---

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -349,7 +349,7 @@ import Images from 'example.jpg?aspect=16:9&h=200;400;700'
 
 • **Keyword**: `withoutEnlargement`<br> • **Type**: _boolean_<br>
 
-Prevents the image from being resized if the specified or calculated width or height are greater than the original width or height.
+Prevents the image from being resized if the specified or calculated width or height are greater than the original width or height. Must be passed with a [width](#width), [height](#height) or [aspect](#aspect) directive.
 
 • **Example**:
 
@@ -365,7 +365,7 @@ import Images from 'example.jpg?aspect=16:9&h=200;400;700&withoutEnlargement'
 
 • **Keyword**: `withoutReduction`<br> • **Type**: _boolean_<br>
 
-Prevents the image from being resized if the specified or calculated width or height are less than the original width or height.
+Prevents the image from being resized if the specified or calculated width or height are less than the original width or height. Must be passed with a [width](#width), [height](#height) or [aspect](#aspect) directive.
 
 • **Example**:
 

--- a/docs/interfaces/core_src.ResizeOptions.md
+++ b/docs/interfaces/core_src.ResizeOptions.md
@@ -81,7 +81,7 @@ ___
 
 ### withoutEnlargement
 
-• **withoutEnlargement**: `boolean`
+• **withoutEnlargement**: ``""`` \| ``"true"``
 
 #### Defined in
 
@@ -91,7 +91,7 @@ ___
 
 ### withoutReduction
 
-• **withoutReduction**: `boolean`
+• **withoutReduction**: ``""`` \| ``"true"``
 
 #### Defined in
 

--- a/docs/interfaces/core_src.ResizeOptions.md
+++ b/docs/interfaces/core_src.ResizeOptions.md
@@ -14,6 +14,8 @@
 - [height](core_src.ResizeOptions.md#height)
 - [w](core_src.ResizeOptions.md#w)
 - [width](core_src.ResizeOptions.md#width)
+- [withoutEnlargement](core_src.ResizeOptions.md#withoutEnlargement)
+- [withoutReduction](core_src.ResizeOptions.md#withoutReduction)
 
 ## Properties
 
@@ -74,3 +76,23 @@ ___
 #### Defined in
 
 [core/src/transforms/resize.ts:9](https://github.com/JonasKruckenberg/imagetools/blob/a033017/packages/core/src/transforms/resize.ts#L9)
+
+___
+
+### withoutEnlargement
+
+• **withoutEnlargement**: `boolean`
+
+#### Defined in
+
+[core/src/transforms/resize.ts:15](https://github.com/JonasKruckenberg/imagetools/blob/a033017/packages/core/src/transforms/resize.ts#L15)
+
+___
+
+### withoutReduction
+
+• **withoutReduction**: `boolean`
+
+#### Defined in
+
+[core/src/transforms/resize.ts:16](https://github.com/JonasKruckenberg/imagetools/blob/a033017/packages/core/src/transforms/resize.ts#L16)

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:213f673dd6d5e6495189856c5b957d8552ee27e0006b9b5da90ae32ed5112007
+size 261558

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d89aa017a20b0c3fe8c4022a95ebef90d3f7c455bc5250ed84d9e6580a041c67
+size 79911

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-multiple-dimensions-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-multiple-dimensions-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895f2fa8cdb7759f75df4b2aff51518cbf1406e1455fdb36268cd129f60736a1
+size 120401

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895f2fa8cdb7759f75df4b2aff51518cbf1406e1455fdb36268cd129f60736a1
+size 120401

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e181c583e927ab42713e23feccff8dbf07dcf2b562ce9ac6d30f36dee19e24
+size 103749

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-height-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-enlargement-2-m-22-mtransform-2-m-22-mw-width-height-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e181c583e927ab42713e23feccff8dbf07dcf2b562ce9ac6d30f36dee19e24
+size 103749

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9c9789ed2600232b7ee33c5e59c804eb8c56cbe48082153732b7c381270c8d
+size 368297

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5ace5880fa995f6ce7fad6c552d7711d3d2c342007b5663878bda3c0b76ca5
+size 513194

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-multiple-dimensions-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-multiple-dimensions-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9c9789ed2600232b7ee33c5e59c804eb8c56cbe48082153732b7c381270c8d
+size 368297

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d9c9fe9c1dd279d60376e8a8fba701752c80b86be69bd0e2e6138fca3a7fe37
+size 711221

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddba1d867eca484e649bb37796305ed57a76ecd54c117a70aba703549bc9f82a
+size 609948

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-height-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-2-m-22-mwithout-reduction-2-m-22-mtransform-2-m-22-mw-width-height-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddba1d867eca484e649bb37796305ed57a76ecd54c117a70aba703549bc9f82a
+size 609948

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:213f673dd6d5e6495189856c5b957d8552ee27e0006b9b5da90ae32ed5112007
+size 261558

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d89aa017a20b0c3fe8c4022a95ebef90d3f7c455bc5250ed84d9e6580a041c67
+size 79911

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-multiple-dimensions-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-multiple-dimensions-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895f2fa8cdb7759f75df4b2aff51518cbf1406e1455fdb36268cd129f60736a1
+size 120401

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895f2fa8cdb7759f75df4b2aff51518cbf1406e1455fdb36268cd129f60736a1
+size 120401

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e181c583e927ab42713e23feccff8dbf07dcf2b562ce9ac6d30f36dee19e24
+size 103749

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-height-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-enlargement-transform-w-width-height-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e181c583e927ab42713e23feccff8dbf07dcf2b562ce9ac6d30f36dee19e24
+size 103749

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9c9789ed2600232b7ee33c5e59c804eb8c56cbe48082153732b7c381270c8d
+size 368297

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5ace5880fa995f6ce7fad6c552d7711d3d2c342007b5663878bda3c0b76ca5
+size 513194

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-multiple-dimensions-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-multiple-dimensions-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9c9789ed2600232b7ee33c5e59c804eb8c56cbe48082153732b7c381270c8d
+size 368297

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d9c9fe9c1dd279d60376e8a8fba701752c80b86be69bd0e2e6138fca3a7fe37
+size 711221

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-height-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-height-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddba1d867eca484e649bb37796305ed57a76ecd54c117a70aba703549bc9f82a
+size 609948

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-height-aspect-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-src-transforms-tests-resize-spec-ts-without-reduction-transform-w-width-height-aspect-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddba1d867eca484e649bb37796305ed57a76ecd54c117a70aba703549bc9f82a
+size 609948

--- a/packages/core/src/transforms/__tests__/resize.spec.ts
+++ b/packages/core/src/transforms/__tests__/resize.spec.ts
@@ -1,10 +1,11 @@
-import { resize } from '../resize'
-import { TransformFactoryContext } from '../../types'
-import { applyTransforms } from '../../index'
-import sharp, { Sharp } from 'sharp'
-import { join } from 'path'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
-import { describe, beforeEach, beforeAll, vi, expect, test } from 'vitest'
+import { join } from 'path'
+import sharp, { Sharp } from 'sharp'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { applyTransforms } from '../../index'
+import { TransformFactoryContext } from '../../types'
+import { resize } from '../resize'
 
 expect.extend({ toMatchImageSnapshot })
 
@@ -360,7 +361,7 @@ describe('aspect', () => {
     })
 
     test('w/ height', async () => {
-     //@ts-expect-error we know this is safe
+      //@ts-expect-error we know this is safe
       const { image } = await applyTransforms([resize({ aspect: '4:3', height: '75' }, dirCtx)], img)
 
       expect(await image.toBuffer()).toMatchImageSnapshot()
@@ -377,6 +378,212 @@ describe('aspect', () => {
       const { image } = await applyTransforms(
         //@ts-expect-error we know this is safe
         [resize({ aspect: '4:3', height: '300', width: '300' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+  })
+})
+
+describe('withoutEnlargement', () => {
+  let dirCtx: TransformFactoryContext
+  beforeAll(() => {
+    dirCtx = { useParam: vi.fn, warn: vi.fn }
+  })
+
+  test('keyword "withoutEnlargement" w/ dimension', () => {
+    const res = resize({ withoutEnlargement: 'true', width: '300' }, dirCtx)
+
+    expect(res).toBeInstanceOf(Function)
+  })
+
+  test('missing', () => {
+    const res = resize({}, dirCtx)
+
+    expect(res).toBeUndefined()
+  })
+
+  test('true w/ missing dimension', () => {
+    const res = resize({ withoutEnlargement: 'true' }, dirCtx)
+
+    expect(res).toBeUndefined()
+  })
+
+  describe('arguments', () => {
+    test('invalid withoutEnlargement', () => {
+      const res = resize({ withoutEnlargement: 'invalid', width: '300' }, dirCtx)
+
+      expect(res).toBeUndefined()
+    })
+
+    test('empty', () => {
+      const res = resize({ withoutEnlargement: '', width: '300' }, dirCtx)
+
+      expect(res).toBeInstanceOf(Function)
+    })
+
+    test('true', () => {
+      const res = resize({ withoutEnlargement: 'true', width: '300' }, dirCtx)
+
+      expect(res).toBeInstanceOf(Function)
+    })
+  })
+
+  describe('transform', () => {
+    let img: Sharp
+    beforeEach(() => {
+      img = sharp(join(__dirname, '../../__tests__/__fixtures__/pexels-allec-gomes-5195763.png'))
+    })
+
+    test('w/ multiple dimensions', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutEnlargement: 'true', width: '300;900' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutEnlargement: 'true', width: '300' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ height', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutEnlargement: 'true', height: '300;900' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ aspect', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutEnlargement: 'true', aspect: '4:3' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width & height', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutEnlargement: 'true', height: '300', width: '300' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width & height & aspect', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutEnlargement: 'true', aspect: '4:3', height: '300', width: '300' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+  })
+})
+
+describe('withoutReduction', () => {
+  let dirCtx: TransformFactoryContext
+  beforeAll(() => {
+    dirCtx = { useParam: vi.fn, warn: vi.fn }
+  })
+
+  test('keyword "withoutReduction"', () => {
+    const res = resize({ withoutReduction: 'true', width: '900' }, dirCtx)
+
+    expect(res).toBeInstanceOf(Function)
+  })
+
+  test('missing', () => {
+    const res = resize({}, dirCtx)
+
+    expect(res).toBeUndefined()
+  })
+
+  test('true w/ missing dimension', () => {
+    const res = resize({ withoutReduction: 'true' }, dirCtx)
+
+    expect(res).toBeUndefined()
+  })
+
+  describe('arguments', () => {
+    test('invalid withoutReduction', () => {
+      const res = resize({ withoutReduction: 'invalid', width: '900' }, dirCtx)
+
+      expect(res).toBeUndefined()
+    })
+
+    test('empty', () => {
+      const res = resize({ withoutReduction: '', width: '900' }, dirCtx)
+
+      expect(res).toBeInstanceOf(Function)
+    })
+
+    test('true', () => {
+      const res = resize({ withoutReduction: 'true', width: '900' }, dirCtx)
+
+      expect(res).toBeInstanceOf(Function)
+    })
+  })
+
+  describe('transform', () => {
+    let img: Sharp
+    beforeEach(() => {
+      img = sharp(join(__dirname, '../../__tests__/__fixtures__/pexels-allec-gomes-5195763.png'))
+    })
+
+    test('w/ multiple dimensions', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutReduction: 'true', width: '300;900' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutReduction: 'true', width: '900' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ height', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ withoutReduction: 'true', height: '900' }, dirCtx)], img)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ aspect', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutReduction: 'true', aspect: '4:3' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width & height', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutReduction: 'true', height: '900', width: '900' }, dirCtx)],
+        img
+      )
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
+    test('w/ width & height & aspect', async () => {
+      const { image } = await applyTransforms(
+        //@ts-expect-error we know this is safe
+        [resize({ withoutReduction: 'true', aspect: '4:3', height: '900', width: '900' }, dirCtx)],
         img
       )
 

--- a/packages/core/src/transforms/__tests__/resize.spec.ts
+++ b/packages/core/src/transforms/__tests__/resize.spec.ts
@@ -412,6 +412,7 @@ describe('withoutEnlargement', () => {
 
   describe('arguments', () => {
     test('invalid withoutEnlargement', () => {
+      //@ts-expect-error invalid args
       const res = resize({ withoutEnlargement: 'invalid', width: '300' }, dirCtx)
 
       expect(res).toBeUndefined()
@@ -515,6 +516,7 @@ describe('withoutReduction', () => {
 
   describe('arguments', () => {
     test('invalid withoutReduction', () => {
+      //@ts-expect-error invalid args
       const res = resize({ withoutReduction: 'invalid', width: '900' }, dirCtx)
 
       expect(res).toBeUndefined()

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -92,7 +92,7 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       finalAspect = originalAspect
 
       console.warn(
-        'withoutEnlargement or withoutReduction active. Image width, height and aspect ratio reverted to original values'
+        '[imagetools] withoutEnlargement or withoutReduction enabled. Image width, height and aspect ratio reverted to original values'
       )
     }
 

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -90,6 +90,10 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       finalHeight = originalHeight
       finalWidth = originalWidth
       finalAspect = originalAspect
+
+      console.warn(
+        'withoutEnlargement or withoutReduction active. Image width, height and aspect ratio reverted to original values'
+      )
     }
 
     setMetadata(image, 'height', finalHeight)

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -48,7 +48,12 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
   const withoutEnlargement = config.withoutEnlargement === '' || config.withoutEnlargement === 'true'
   const withoutReduction = config.withoutReduction === '' || config.withoutReduction === 'true'
 
-  if (!width && !height && !aspect) return
+  if (
+    (!width && !height && !aspect) ||
+    (config.withoutEnlargement && !withoutEnlargement) ||
+    (config.withoutReduction && !withoutReduction)
+  )
+    return
 
   return function resizeTransform(image) {
     // calculate finalWidth & finalHeight
@@ -82,7 +87,6 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       (withoutEnlargement && (finalHeight > originalHeight || finalWidth > originalWidth)) ||
       (withoutReduction && (finalHeight < originalHeight || finalWidth < originalWidth))
     ) {
-      // revert back to original sizes if either width or height exceeds or subceeds
       finalHeight = originalHeight
       finalWidth = originalWidth
       finalAspect = originalAspect
@@ -91,12 +95,14 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
     setMetadata(image, 'height', finalHeight)
     setMetadata(image, 'width', finalWidth)
     setMetadata(image, 'aspect', finalAspect)
+    setMetadata(image, 'withoutEnlargement', withoutEnlargement)
+    setMetadata(image, 'withoutReduction', withoutReduction)
 
     return image.resize({
       width: Math.round(finalWidth) || undefined,
       height: Math.round(finalHeight) || undefined,
-      withoutEnlargement: false,
-      withoutReduction: false,
+      withoutEnlargement: withoutEnlargement,
+      withoutReduction: withoutReduction,
       fit: getFit(config, image),
       position: getPosition(config, image),
       kernel: getKernel(config, image),

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -92,7 +92,7 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       finalAspect = originalAspect
 
       console.warn(
-        '[imagetools] withoutEnlargement or withoutReduction enabled. Image width, height and aspect ratio reverted to original values'
+        '[vite-imagetools] withoutEnlargement or withoutReduction enabled. Image width, height and aspect ratio reverted to original values'
       )
     }
 

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -81,7 +81,7 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       (withoutEnlargement && (finalHeight > originalHeight || finalWidth > originalWidth)) ||
       (withoutReduction && (finalHeight < originalHeight || finalWidth < originalWidth))
     ) {
-      // revert back to original sizes if either width or height exceeds or subsceeds
+      // revert back to original sizes if either width or height exceeds or subceeds
       finalHeight = originalHeight
       finalWidth = originalWidth
     }

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -57,7 +57,8 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
     const originalAspect = originalWidth / originalHeight
 
     let finalWidth = width,
-      finalHeight = height
+      finalHeight = height,
+      finalAspect = aspect
 
     if (aspect && !width && !height) {
       // only aspect was given, need to calculate which dimension to crop
@@ -84,11 +85,12 @@ export const resize: TransformFactory<ResizeOptions> = (config) => {
       // revert back to original sizes if either width or height exceeds or subceeds
       finalHeight = originalHeight
       finalWidth = originalWidth
+      finalAspect = originalAspect
     }
 
     setMetadata(image, 'height', finalHeight)
     setMetadata(image, 'width', finalWidth)
-    setMetadata(image, 'aspect', aspect || originalAspect)
+    setMetadata(image, 'aspect', finalAspect)
 
     return image.resize({
       width: Math.round(finalWidth) || undefined,


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added boolean `withoutEnlargement` and `withoutReduction` flags to prevent image resizing if active and the calculated with or height exceeds or subceeds the original size.

- **What is the new behavior (if this is a feature change)?**
Default behavior remains the same but users can add `&withoutEnglargment` or `&withoutReduction` to prevent unwanted resizing. Images are still created as Sharp sees fit.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No breaking change as `withoutEnlargement` and `withoutReduction` are opt-in per Sharp's API.

- **Other information**:
Closes #460 and touches #257. 

1. Check that either flag is present (`'' || 'true'`)
2. Check that the finalWidth and finalHeight do not subceed/exceed according to each parameter
3. If either is flagged, revert to original image size

Sharp's [fastShrinkOnLoad](https://sharp.pixelplumbing.com/api-resize) could be added while we are here.