### PR TITLE
fix: types exports must come first

### DIFF
--- a/.changeset/nervous-ads-draw.md
+++ b/.changeset/nervous-ads-draw.md
@@ -1,0 +1,6 @@
+---
+'rollup-plugin-imagetools': patch
+'vite-imagetools': patch
+---
+
+fix: list types exports first

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -5,9 +5,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -6,9 +6,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [X] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** Fix

- **What is the new behavior (if this is a feature change)?** Put `types` first. https://publint.dev/vite-imagetools@4.0.14

- **Does this PR introduce a breaking change?** No - bug fix

- **Other information**:
