### PR TITLE
support Vite's `base` config when using the dev server

### DIFF
--- a/.changeset/pink-yaks-jam.md
+++ b/.changeset/pink-yaks-jam.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': minor
+---
+
+support Vite's base config when the dev server is running

--- a/.changeset/pink-yaks-jam.md
+++ b/.changeset/pink-yaks-jam.md
@@ -1,5 +1,5 @@
 ---
-'vite-imagetools': minor
+'vite-imagetools': patch
 ---
 
 support Vite's base config when the dev server is running

--- a/.changeset/pink-yaks-jam.md
+++ b/.changeset/pink-yaks-jam.md
@@ -2,4 +2,4 @@
 'vite-imagetools': patch
 ---
 
-support Vite's base config when the dev server is running
+fix: support Vite's `base` config

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "4.0.16-0.0.1",
   "name": "imagetools",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "4.0.16-0.0.1",
   "name": "imagetools",
   "license": "MIT",
   "private": true,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -46,7 +46,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     enforce: 'pre',
     configResolved(cfg) {
       viteConfig = cfg
-      basePath = viteConfig.base || '/'
+      basePath = viteConfig.base?.replace(/\/$/, '') || ''
     },
     async load(id) {
       if (!filter(id)) return null
@@ -120,8 +120,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (req.url?.startsWith(`${basePath}@imagetools/`)) {
-          const [, id] = req.url.split(`${basePath}@imagetools/`)
+        if (req.url?.startsWith(`${basePath}/@imagetools/`)) {
+          const [, id] = req.url.split(`${basePath}/@imagetools/`)
 
           const image = generatedImages.get(id)
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -37,6 +37,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     : builtinOutputFormats
 
   let viteConfig: ResolvedConfig
+	let basePath: string
 
   const generatedImages = new Map()
 
@@ -45,6 +46,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     enforce: 'pre',
     configResolved(cfg) {
       viteConfig = cfg
+			basePath = viteConfig.base || '/'
     },
     async load(id) {
       if (!filter(id)) return null
@@ -88,7 +90,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = posix.join(`${viteConfig.json?.base}/@imagetools`, id)
+          metadata.src = posix.join(basePath, '@imagetools', id)
         }
 
         metadata.image = image
@@ -118,8 +120,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (req.url?.startsWith(`${viteConfig.json?.base}/@imagetools/`)) {
-          const [, id] = req.url.split(`${viteConfig.json?.base}/@imagetools/`)
+        if (req.url?.startsWith(`${basePath}@imagetools/`)) {
+          const [, id] = req.url.split(`${basePath}@imagetools/`)
 
           const image = generatedImages.get(id)
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -37,7 +37,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     : builtinOutputFormats
 
   let viteConfig: ResolvedConfig
-	let basePath: string
+  let basePath: string
 
   const generatedImages = new Map()
 
@@ -46,7 +46,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     enforce: 'pre',
     configResolved(cfg) {
       viteConfig = cfg
-			basePath = viteConfig.base || '/'
+      basePath = viteConfig.base || '/'
     },
     async load(id) {
       if (!filter(id)) return null

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -88,7 +88,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = posix.join('/@imagetools', id)
+          metadata.src = posix.join(`${viteConfig.json?.base/@imagetools`, id)
         }
 
         metadata.image = image
@@ -118,8 +118,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (req.url?.startsWith('/@imagetools/')) {
-          const [, id] = req.url.split('/@imagetools/')
+        if (req.url?.startsWith(`${viteConfig.json?.base}/@imagetools/`)) {
+          const [, id] = req.url.split(`${viteConfig.json?.base}/@imagetools/`)
 
           const image = generatedImages.get(id)
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -88,7 +88,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = posix.join(`${viteConfig.json?.base/@imagetools`, id)
+          metadata.src = posix.join(`${viteConfig.json?.base}/@imagetools`, id)
         }
 
         metadata.image = image


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It adds support for Vite's `base` config in the dev server. This fixes issues with serving assets through imagetools when using a custom backend, such as Rails.

Fixes #396.

- **What is the new behavior (if this is a feature change)?**

The URL prefix used to watch for imagetools requests is now `${viteConfig.base}/@imagetools/` instead of just `/@imagetools/`. This allows for things like Rails to properly forward those requests to the Vite dev server.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

I don't think so, no.