### PR TITLE
Update missing import in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,7 +34,7 @@ yarn add imagetools-core
 ## Usage
 
 ```js
-import { loadImage, applyTransforms, builtins } from 'imagetools-core'
+import { loadImage, applyTransforms, builtins, generateTransforms } from 'imagetools-core'
 
 // loadImageFromDisk is a utility function that creates a sharp instances of the specified image
 const image = loadImage('./example.jpg')


### PR DESCRIPTION
One of the examples in the README was missing the `generateTransforms` import.

- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix missing import in an example README.

- **What is the new behavior (if this is a feature change)?**
All examples in the README work when used.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

- **Other information**:
