### PR TITLE
fix: basePath must support not only path, but url in watch mode

### DIFF
--- a/.changeset/unlucky-maps-burn.md
+++ b/.changeset/unlucky-maps-burn.md
@@ -1,0 +1,5 @@
+---
+"vite-imagetools": patch
+---
+
+fix: support URL with scheme in base option

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -46,7 +46,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
     enforce: 'pre',
     configResolved(cfg) {
       viteConfig = cfg
-      basePath = viteConfig.base?.replace(/\/$/, '') || ''
+      basePath = (viteConfig.base?.replace(/\/$/, '') || '') + '/@imagetools/'
     },
     async load(id) {
       if (!filter(id)) return null
@@ -96,7 +96,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = `${basePath}/@imagetools/${id}`
+          metadata.src = basePath + id
         }
 
         metadata.image = image
@@ -126,8 +126,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (req.url?.startsWith(`${basePath}/@imagetools/`)) {
-          const [, id] = req.url.split(`${basePath}/@imagetools/`)
+        if (req.url?.startsWith(basePath)) {
+          const [, id] = req.url.split(basePath)
 
           const image = generatedImages.get(id)
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -13,7 +13,7 @@ import {
   extractEntries,
   Logger
 } from 'imagetools-core'
-import { basename, extname, posix } from 'path'
+import { basename, extname } from 'path'
 import { createFilter, dataToEsm } from '@rollup/pluginutils'
 import { VitePluginOptions } from './types'
 
@@ -96,7 +96,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = basePath + posix.join('/@imagetools', id)
+          metadata.src = `${basePath}/@imagetools/${id}`
         }
 
         metadata.image = image

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -96,7 +96,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           metadata.src = `__VITE_ASSET__${fileHandle}__`
         } else {
-          metadata.src = posix.join(basePath, '/@imagetools', id)
+          metadata.src = basePath + posix.join('/@imagetools', id)
         }
 
         metadata.image = image


### PR DESCRIPTION
Tested locally with different base param value

base: "http://localhost:3000" — http://localhost:3000/@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "http://localhost:3000/base" — http://localhost:3000/base/@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "http://localhost:3000/base/" — http://localhost:3000/base/@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "/base/" — /base/@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "/base" — /base/@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "/" — /@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2
base: "" — /@imagetools/d99ae1dc2434acf7a940ad240f75c5e9373463f2

Closes: #500 

- **Quick Checklist**

* [ ] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

- **What is the new behavior (if this is a feature change)?**
Support base param with url in watch mode

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

- **Other information**:
