### PR TITLE
fix: allow async output formats

### DIFF
--- a/.changeset/cool-books-enjoy.md
+++ b/.changeset/cool-books-enjoy.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: allow async output formats

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -118,7 +118,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         }
       }
 
-      return dataToEsm(outputFormat(outputMetadatas), {
+      return dataToEsm(await outputFormat(outputMetadatas), {
         namedExports: viteConfig.json?.namedExports ?? true,
         compact: !!viteConfig.build.minify ?? false,
         preferConst: true


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes https://github.com/JonasKruckenberg/imagetools/issues/463 and https://github.com/JonasKruckenberg/imagetools/pull/369#issuecomment-1229161855, since it's possible that output format ops may be async.

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

Nope.

- **Other information**:

I'm still facing an unrelated test failure on a brand new `imagetools` setup as described in https://github.com/JonasKruckenberg/imagetools/issues/506. Happy to rebase if that get resolved.
