### PR TITLE
fix: don't match extensions in query string

### DIFF
--- a/.changeset/eight-pets-arrive.md
+++ b/.changeset/eight-pets-arrive.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: don't match extensions in query string

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -19,7 +19,7 @@ import { VitePluginOptions } from './types'
 import { createBasePath } from './utils'
 
 const defaultOptions: VitePluginOptions = {
-  include: ['**/*.{heic,heif,avif,jpeg,jpg,png,tiff,webp,gif}', '**/*.{heic,heif,avif,jpeg,jpg,png,tiff,webp,gif}?*'],
+  include: /^[^?]+\.(heic|heif|avif|jpeg|jpg|png|tiff|webp|gif)(\?.*)?$/,
   exclude: 'public/**/*',
   removeMetadata: true
 }


### PR DESCRIPTION
closes https://github.com/JonasKruckenberg/imagetools/issues/521