### PR TITLE
Make output format a URL parameter value instead of key

### DIFF
--- a/.changeset/brown-jars-protect.md
+++ b/.changeset/brown-jars-protect.md
@@ -1,0 +1,6 @@
+---
+'imagetools-core': major
+'vite-imagetools': major
+---
+
+breaking: removed shorthands (e.g. webp as a standalone query parameter). You must now specify the full `format=`

--- a/.changeset/ninety-pugs-burn.md
+++ b/.changeset/ninety-pugs-burn.md
@@ -3,5 +3,4 @@
 'vite-imagetools': major
 ---
 
-breaking: simplify ability to provide defaults. Image format is now specified with `format=` and output format is now
-specified with `as=`
+breaking: simplify ability to provide defaults. Output format is now specified with `as=`

--- a/.changeset/ninety-pugs-burn.md
+++ b/.changeset/ninety-pugs-burn.md
@@ -1,0 +1,7 @@
+---
+'imagetools-core': major
+'vite-imagetools': major
+---
+
+breaking: simplify ability to provide defaults. Image format is now specified with `format=` and output format is now
+specified with `as=`

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -141,20 +141,17 @@ import Image from 'exmaple.jpg?flop=true'
 ### Format
 
 • **Keyword**: `format`<br> • **Type**: _heic_\| _heif_ \| _avif_ \| _jpeg_ \| _jpg_ \| _png_ \| _tiff_ \| _webp_ \|
-_gif_<br> • **Shorthands**: `heic`\| `heif` \| `avif` \| `jpg` \|`jpeg` \| `png` \| `tiff` \| `webp` \| (`gif`)<br>
+_gif_<br>
 
 Convert the image into the given format.
 
 > NOTE: Converting to the `gif` format requires libvips compiled with support for ImageMagick or GraphicsMagick See
 > [The sharp docs](https://sharp.pixelplumbing.com/install#custom-libvips) for details.
 
-> You cannot use multiple shorthands, use `format` instead.
-
 • **Example**:
 
 ```js
 import Image from 'example.jpg?format=webp'
-import Image from 'example.jpg?png'
 import Images from 'example.jpg?format=webp;avif;heic'
 ```
 
@@ -286,7 +283,7 @@ The argument must be a number between 0 and 100.
 
 ```js
 import Image from 'example.jpg?format=webp&quality=100'
-import Images from 'example.jpg?avif&quality=10;50;75'
+import Images from 'example.jpg?format=avif&quality=10;50;75'
 ```
 
 ---
@@ -421,7 +418,7 @@ Returns all information collected about the image as a JavaScript object. The di
 
 ```js
 import Image from 'example.jpg?w=500;900;1200&avif&metadata'
-import { height, format } from 'example.jpg?w=700&gif&as=meta:height;format'
+import { height, format } from 'example.jpg?w=700&format=gif&as=meta:height;format'
 ```
 
 ### Picture
@@ -451,8 +448,8 @@ Returns information about the image necessary to render a `source` tag as a Java
 • **Example**:
 
 ```js
-import avif from 'example.jpg?w=500;900;1200&avif&as=source'
-import webp from 'example.jpg?w=500;900;1200&webp&as=source'
+import avif from 'example.jpg?w=500;900;1200&format=avif&as=source'
+import webp from 'example.jpg?w=500;900;1200&format=webp&as=source'
 import fallback from 'example.jpg?w=700'
 
 const html = `<picture>
@@ -471,8 +468,8 @@ Returns a srcset string of the generated images to be used in a `<picture>` tag.
 • **Example**:
 
 ```js
-import avif from 'example.jpg?w=500;900;1200&avif&srcset'
-import webp from 'example.jpg?w=500;900;1200&webp&srcset'
+import avif from 'example.jpg?w=500;900;1200&format=avif&as=srcset'
+import webp from 'example.jpg?w=500;900;1200&format=webp&as=srcset'
 import fallback from 'example.jpg?w=700'
 
 const html = `<picture>

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -421,7 +421,7 @@ Returns all information collected about the image as a JavaScript object. The di
 
 ```js
 import Image from 'example.jpg?w=500;900;1200&avif&metadata'
-import { height, format } from 'example.jpg?w=700&gif&meta=height;format'
+import { height, format } from 'example.jpg?w=700&gif&as=meta:height;format'
 ```
 
 ### Picture
@@ -433,7 +433,7 @@ Returns information about the image necessary to render a `picture` tag as a Jav
 • **Example**:
 
 ```js
-import image from 'example.jpg?w=500;900;1200&format=avif;webp;jpg&picture'
+import image from 'example.jpg?w=500;900;1200&format=avif;webp;jpg&as=picture'
 
 let html = '<picture>';
 for (const [format, images] of Object.entries(image.sources)) {
@@ -451,8 +451,8 @@ Returns information about the image necessary to render a `source` tag as a Java
 • **Example**:
 
 ```js
-import avif from 'example.jpg?w=500;900;1200&avif&source'
-import webp from 'example.jpg?w=500;900;1200&webp&source'
+import avif from 'example.jpg?w=500;900;1200&avif&as=source'
+import webp from 'example.jpg?w=500;900;1200&webp&as=source'
 import fallback from 'example.jpg?w=700'
 
 const html = `<picture>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,7 +12,7 @@ export default defineConfig({
 Now you can transform image by importing them like this:
 
 ```js
-import Image from 'example.jpg?w=400&h=300&webp'
+import Image from 'example.jpg?w=400&h=300&format=webp'
 ```
 
 ## Basic usage
@@ -46,28 +46,13 @@ multiple directives with multiple arguments:
 
 This will generate 9 different images, one for each combination of width and format.
 
-## Shorthands
-
-As you've seen, having a lot of directives on a single image makes the import statement very hard to read.<br> This is
-why the most commonly used transforms have shorthands that you can use instead. So writing:
-
-```
-<url>?format=webp
-```
-
-Is equivalent to writing:
-
-```
-<url>?webp
-```
-
 ## Metadata
 
 Normally you get a single url pointing to the transformed image, or an array of those. There are situations however, where you'd like to have more information about the image, e.g. the images width and height or format.
 This is why the special `metadata` (`meta`) directive exists. Instead of returning the url it returns an object holding the image metadata:
 
 ```js
-import { width, height, format, src } from 'example.jpg?width=300&webp&metadata'
+import { width, height, format, src } from 'example.jpg?width=300&format=webp&as=metadata'
 
 width // is 300
 height // is automatically generated

--- a/examples/vite-simple/README.md
+++ b/examples/vite-simple/README.md
@@ -8,8 +8,8 @@ The example creates a simple `picture` element, that has 2 different dynamically
 image format and one in `webp` for all browsers that don't support avif (like safari).
 
 ```ts
-import srcsetAvif from '../example.jpg?w=500;700;900;1200&avif&srcset'
-import srcsetWebp from '../example.jpg?w=500;700;900;1200&webp&srcset'
+import srcsetAvif from '../example.jpg?w=500;700;900;1200&format=avif&as=srcset'
+import srcsetWebp from '../example.jpg?w=500;700;900;1200&format=webp&as=srcset'
 ```
 
 The last import above for example instructs imagetools to do the following:

--- a/examples/vite-simple/main.js
+++ b/examples/vite-simple/main.js
@@ -1,10 +1,10 @@
 import './style.css'
 // import 3 different sizes of the image and create a srcset from them
-import srcsetAvif from '../example.jpg?w=500;700;900;1200&avif&srcset'
+import srcsetAvif from '../example.jpg?w=500;700;900;1200&format=avif&as=srcset'
 // do it a second time, but now as webp since safari can't display avif
-import srcsetWebp from '../example.jpg?w=500;700;900;1200&webp&srcset'
+import srcsetWebp from '../example.jpg?w=500;700;900;1200&format=webp&as=srcset'
 // create a small placeholder and import its metadata
-import { src as placeholder, width, height } from '../example.jpg?width=300&metadata'
+import { src as placeholder, width, height } from '../example.jpg?width=300&as=metadata'
 
 document.querySelector('#app').innerHTML = `
   <h1>Hello Imagetools!</h1>

--- a/packages/core/src/lib/parse-url.ts
+++ b/packages/core/src/lib/parse-url.ts
@@ -6,7 +6,8 @@ export function extractEntries(searchParams: URLSearchParams) {
   const entries: Array<[string, string[]]> = []
 
   for (const [key, value] of searchParams) {
-    entries.push([key, value.split(';')])
+    const values = value.includes(':') ? [value] : value.split(';')
+    entries.push([key, values])
   }
 
   return entries

--- a/packages/core/src/lib/resolve-configs.ts
+++ b/packages/core/src/lib/resolve-configs.ts
@@ -23,7 +23,7 @@ export function resolveConfigs(
     .filter(([k]) => !(k in outputFormats))
     .map(([key, values]) => values.map<[[string, string]]>((v) => [[key, v]]))
 
-  // do a cartesian product on all entries to get all combainations we need to produce
+  // do a cartesian product on all entries to get all combinations we need to produce
   const combinations = singleArgumentEntries
     // .filter(([key]) => !(key[0][0] in outputFormats))
     .reduce((prev, cur) => (prev.length ? cartesian(prev, cur) : cur), [])

--- a/packages/core/src/transforms/__tests__/format.spec.ts
+++ b/packages/core/src/transforms/__tests__/format.spec.ts
@@ -29,30 +29,8 @@ describe('format', () => {
     expect(res).toBeUndefined()
   })
 
-  describe('shorthands', () => {
-    test('invalid', () => {
-      const formats = ['avif', 'jpg', 'jpeg', 'png', 'heif', 'heic', 'webp', 'tiff']
-
-      for (const f of formats) {
-        const res = format({ [f]: 'invalid' }, dirCtx)
-
-        expect(res).toBeUndefined()
-      }
-    })
-
-    test('valid', () => {
-      const formats = ['avif', 'jpg', 'jpeg', 'png', 'heif', 'heic', 'webp', 'tiff']
-
-      for (const f of formats) {
-        const res = format({ [f]: '' }, dirCtx)
-
-        expect(res).toBeInstanceOf(Function)
-      }
-    })
-  })
-
   describe('arguments', () => {
-    test('inavlid', () => {
+    test('invalid', () => {
       //@ts-expect-error invalid args
       const res = format({ format: 'invalid' }, dirCtx)
 

--- a/packages/core/src/transforms/format.ts
+++ b/packages/core/src/transforms/format.ts
@@ -17,8 +17,6 @@ export const format: TransformFactory<FormatOptions> = (config) => {
 
   if (config.format && formatValues.includes(config.format)) {
     format = config.format
-  } else {
-    format = Object.keys(config).find((k: any): k is FormatValue => formatValues.includes(k) && config[k] === '')
   }
   if (!format) return
 

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -163,12 +163,12 @@ transforms before applying them to the input image.
 
 ### resolveConfigs
 
-• `Optional` **resolveConfigs**: (`entries`: [`string`, `string`[]][], `outputFormats`: `Record`<`string`,
-[`OutputFormat`](../modules/core_src.md#outputformat)\>) => `Record`<`string`, `string` \| `string`[]\>[]
+• `Optional` **resolveConfigs**: (`entries`: `[string, string[]][]`, `outputFormats`: `Record`<`string`,
+[`OutputFormat`](../modules/core_src.md#outputformat)\>) => `Record<string, string | string[]>[]`
 
 #### Type declaration
 
-▸ (`entries`, `outputFormats`): `Record`<`string`, `string` \| `string`[]\>[]
+▸ (`entries`, `outputFormats`): `Record<string, string | string[]>[]`
 
 This function builds up all possible combinations the given entries can be combined an returns it as an array of objects
 that can be given to a the transforms.
@@ -177,12 +177,12 @@ that can be given to a the transforms.
 
 | Name            | Type                                                                       | Description               |
 | :-------------- | :------------------------------------------------------------------------- | :------------------------ |
-| `entries`       | [`string`, `string`[]][]                                                   | The url parameter entries |
+| `entries`       | `[string, string[]][]`                                                     | The url parameter entries |
 | `outputFormats` | `Record`<`string`, [`OutputFormat`](../modules/core_src.md#outputformat)\> | -                         |
 
 ##### Returns
 
-`Record`<`string`, `string` \| `string`[]\>[]
+`Record<string, string | string[]>[]`
 
 An array of directive options
 

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -50,7 +50,7 @@ export default defineConfig({
 ```
 
 ```js
-import Image from 'example.jpg?w=400&h=300&webp'
+import Image from 'example.jpg?w=400&h=300&format=webp'
 ```
 
 ## Options

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -309,7 +309,7 @@ describe('vite-imagetools', () => {
           build: { write: false },
           plugins: [
             testEntry(`
-                            import Image from "./with-metadata.png?metadata"
+                            import Image from "./with-metadata.png?as=metadata"
                             window.__IMAGE__ = Image
                         `),
             imagetools({
@@ -332,7 +332,7 @@ describe('vite-imagetools', () => {
           build: { write: false },
           plugins: [
             testEntry(`
-                            import Image from "./with-metadata.png?metadata"
+                            import Image from "./with-metadata.png?as=metadata"
                             window.__IMAGE__ = Image
                         `),
             imagetools({
@@ -357,7 +357,7 @@ describe('vite-imagetools', () => {
           build: { write: false },
           plugins: [
             testEntry(`
-                            import Image from "./with-metadata.png?metadata"
+                            import Image from "./with-metadata.png?as=metadata"
                             window.__IMAGE__ = Image
                         `),
             imagetools({
@@ -432,7 +432,7 @@ describe('vite-imagetools', () => {
             imagetools({
               defaultDirectives: (id) => {
                 if (id.searchParams.has('mypreset')) {
-                  return new URLSearchParams('metadata')
+                  return new URLSearchParams('as=metadata')
                 }
                 return new URLSearchParams()
               }
@@ -556,7 +556,7 @@ describe('vite-imagetools', () => {
       build: { write: false },
       plugins: [
         testEntry(`
-                    import Image from "./pexels-allec-gomes-5195763.png?metadata"
+                    import Image from "./pexels-allec-gomes-5195763.png?as=metadata"
                     window.__IMAGE__ = Image
                 `),
         imagetools()
@@ -587,7 +587,7 @@ describe('vite-imagetools', () => {
       build: { write: false },
       plugins: [
         testEntry(`
-                    import { width, height, format } from "./pexels-allec-gomes-5195763.png?metadata"
+                    import { width, height, format } from "./pexels-allec-gomes-5195763.png?as=metadata"
                     window.__IMAGE__ = { width, height, format }
                 `),
         imagetools()
@@ -610,7 +610,7 @@ describe('vite-imagetools', () => {
       build: { write: false },
       plugins: [
         testEntry(`
-                    import { width, format } from "./pexels-allec-gomes-5195763.png?metadata=width;format"
+                    import { width, format } from "./pexels-allec-gomes-5195763.png?as=metadata:width;format"
                     window.__IMAGE__ = { width, format }
                 `),
         imagetools()
@@ -633,7 +633,7 @@ describe('vite-imagetools', () => {
       build: { write: false },
       plugins: [
         testEntry(`
-                        import Image from "./with-metadata.png?srcset"
+                        import Image from "./with-metadata.png?as=srcset"
                         window.__IMAGE__ = Image
                     `),
         imagetools()
@@ -654,7 +654,7 @@ describe('vite-imagetools', () => {
       build: { write: false },
       plugins: [
         testEntry(`
-          import Image from "./with-metadata.png?run"
+          import Image from "./with-metadata.png?as=run"
           window.__IMAGE__ = Image
         `),
         imagetools({

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -106,14 +106,11 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       }
 
       let outputFormat = urlFormat()
-
+      const asParam = directives.get('as')?.split(':')
+      const as = asParam ? asParam[0] : undefined
       for (const [key, format] of Object.entries(outputFormats)) {
-        if (directives.has(key)) {
-          const params = directives
-            .get(key)
-            ?.split(';')
-            .filter((v: string) => !!v)
-          outputFormat = format(params?.length ? params : undefined)
+        if (as === key) {
+          outputFormat = format(asParam && asParam[1] ? asParam[1].split(';') : undefined)
           break
         }
       }


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [X] I have written new tests, as applicable (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)
* [X] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** Feature

- **What is the new behavior (if this is a feature change)?** 

Simplify ability to provide defaults. Image format is now specified with `format=` and output format is now specified with `as=`.

Formats are most often specified with `defaultDirectives` and presets and this makes using both of those features much easier at the expense of making exceptions slightly more verbose. It also adds clarity as there's only a single way to do things vs multiple

You can see how much simpler this becomes in the example in https://github.com/JonasKruckenberg/imagetools/issues/536

- **Does this PR introduce a breaking change?** Yes

- **Other information**: Closes https://github.com/JonasKruckenberg/imagetools/issues/536