### PR TITLE
fix: combine directives with defaultDirectives correctly

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -12,6 +12,7 @@ import {
   builtinOutputFormats,
   urlFormat,
   extractEntries,
+  ImageConfig,
   Logger
 } from 'imagetools-core'
 import { createFilter, dataToEsm } from '@rollup/pluginutils'
@@ -57,9 +58,15 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       let directives = srcURL.searchParams
 
       if (typeof pluginOptions.defaultDirectives === 'function') {
-        directives = new URLSearchParams([...pluginOptions.defaultDirectives(srcURL), ...srcURL.searchParams])
+        directives = new URLSearchParams({
+          ...Object.fromEntries(pluginOptions.defaultDirectives(srcURL)),
+          ...Object.fromEntries(srcURL.searchParams)
+        })
       } else if (pluginOptions.defaultDirectives) {
-        directives = new URLSearchParams([...pluginOptions.defaultDirectives, ...srcURL.searchParams])
+        directives = new URLSearchParams({
+          ...Object.fromEntries(pluginOptions.defaultDirectives),
+          ...Object.fromEntries(srcURL.searchParams)
+        })
       }
 
       if (!directives.toString()) return null
@@ -70,7 +77,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
       const img = loadImage(decodeURIComponent(srcURL.pathname))
 
-      const outputMetadatas = []
+      const outputMetadatas: Array<ImageConfig> = []
 
       const logger: Logger = {
         info: (msg) => viteConfig.logger.info(msg),


### PR DESCRIPTION
If you had `defaultDirectives: new URLSearchParams({ w: '100;200;400;800' })` and `image.png?w=300,500` then you'd end up with `[[100, 200, 400, 800], [300, 500]]` which would then get combined into 8 different sizes by `resolveConfig`.

Assuming `defaultDirectives` is supposed to be used for defaults then this seems incorrect. It's possible that the intended usage is for the user to check whether a parameter is specified before providing it, but this seems unlikely as the non-function form would only work if the user never provided any per-image override. In that case, the design would be brittle and the name would be misleading, so I'm assuming that's not how it's to be used