### PR TITLE
breaking: drop CJS support

### DIFF
--- a/.changeset/few-hairs-lay.md
+++ b/.changeset/few-hairs-lay.md
@@ -1,0 +1,6 @@
+---
+'imagetools-core': major
+'vite-imagetools': major
+---
+
+breaking: drop CJS support

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "imagetools-core",
   "version": "3.3.1",
+  "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,11 +4,8 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
+    "import": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -10,13 +10,7 @@ export default {
   output: [
     {
       dir: './dist',
-      entryFileNames: '[name].cjs',
-      format: 'cjs',
-      sourcemap: true
-    },
-    {
-      dir: './dist',
-      entryFileNames: '[name].mjs',
+      entryFileNames: '[name].js',
       format: 'esm',
       sourcemap: true
     }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,6 +2,7 @@
   "name": "vite-imagetools",
   "description": "Load and transform images using a toolbox of import directives!",
   "version": "4.0.19",
+  "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -5,12 +5,8 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    }
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -10,13 +10,7 @@ export default {
   output: [
     {
       dir: './dist',
-      entryFileNames: '[name].cjs',
-      format: 'cjs',
-      sourcemap: true
-    },
-    {
-      dir: './dist',
-      entryFileNames: '[name].mjs',
+      entryFileNames: '[name].js',
       format: 'esm',
       sourcemap: true
     }


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [X] I have written new tests, as applicable (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)
* [X] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** improvement

- **What is the new behavior (if this is a feature change)?** only build an ESM version. This will make compilation twice as fast and make the package only half as large. It also makes debugging easier because you don't have to figure out which version was loaded as there's only a single version

- **Does this PR introduce a breaking change?** Yes

- **Other information**:
