### PR TITLE
fix: multiple transforms now survive `resolveConfig`

### DIFF
--- a/packages/core/src/__tests__/generate-configs.spec.ts
+++ b/packages/core/src/__tests__/generate-configs.spec.ts
@@ -52,6 +52,39 @@ describe('generateConfigs', () => {
     expect(res).toHaveLength(2)
   })
 
+  // test('the returned array length equals the product of all arguments', () => {
+  //   {
+  //     const e: [string, string[]][] = [['width', ['300', '400']]]
+
+  //     const res = resolveConfigs(e, builtinOutputFormats)
+
+  //     expect(res).toHaveLength(2)
+  //   }
+  //   {
+  //     const e: [string, string[]][] = [
+  //       ['width', ['300', '400']],
+  //       ['test', ['foo', 'bar']]
+  //     ]
+
+  //     const res = resolveConfigs(e, builtinOutputFormats)
+
+  //     console.log(res)
+
+  //     expect(res).toHaveLength(4)
+  //   }
+  //   {
+  //     const e: [string, string[]][] = [
+  //       ['width', ['300', '400']],
+  //       ['test', ['foo', 'bar']],
+  //       ['height', ['100', '700']]
+  //     ]
+
+  //     const res = resolveConfigs(e, builtinOutputFormats)
+
+  //     expect(res).toHaveLength(8)
+  //   }
+  // })
+
   test('the returned array length equals the product of all arguments', () => {
     {
       const e: [string, string[]][] = [['width', ['300', '400']]]
@@ -68,6 +101,8 @@ describe('generateConfigs', () => {
 
       const res = resolveConfigs(e, builtinOutputFormats)
 
+      console.log(res)
+
       expect(res).toHaveLength(4)
     }
     {
@@ -80,6 +115,48 @@ describe('generateConfigs', () => {
       const res = resolveConfigs(e, builtinOutputFormats)
 
       expect(res).toHaveLength(8)
+    }
+  })
+
+  test('the returned array contains the product of all arguments', () =>{
+    {
+      const e: [string, string[]][] = [
+        ['width', ['300', '400']],
+        ['test', ['foo', 'bar']]
+      ]
+
+      const expected = [
+        { width: '300', test: 'foo'},
+        { width: '300', test: 'bar'},
+        { width: '400', test: 'foo'},
+        { width: '300', test: 'bar'},
+      ]
+
+      const res = resolveConfigs(e, builtinOutputFormats)
+
+      expected.forEach(entry => {expect(res).toContainEqual(entry)})
+    }
+    {
+      const e: [string, string[]][] = [
+        ['width', ['300', '400']],
+        ['test', ['foo', 'bar']],
+        ['height', ['100', '700']]
+      ]
+
+      const expected = [
+        { width: '300', test: 'foo', height: '100'},
+        { width: '300', test: 'foo', height: '700'},
+        { width: '300', test: 'bar', height: '100'},
+        { width: '300', test: 'bar', height: '700'},
+        { width: '400', test: 'foo', height: '100'},
+        { width: '400', test: 'foo', height: '700'},
+        { width: '400', test: 'bar', height: '100'},
+        { width: '400', test: 'bar', height: '700'},
+      ]
+
+      const res = resolveConfigs(e, builtinOutputFormats)
+
+      expected.forEach(entry => {expect(res).toContainEqual(entry)})
     }
   })
 
@@ -106,6 +183,7 @@ describe('generateConfigs', () => {
     ]
 
     const res = resolveConfigs(e, builtinOutputFormats)
+    // console.log(res)
 
     expect(res).toHaveLength(4)
   })

--- a/packages/core/src/lib/resolve-configs.ts
+++ b/packages/core/src/lib/resolve-configs.ts
@@ -31,9 +31,22 @@ export function resolveConfigs(
   const metadataAddons = entries.filter(([k]) => k in outputFormats)
 
   // and return as an array of objects
-  const out: Record<string, string | string[]>[] = combinations.map((options) =>
-    Object.fromEntries([[...options, ...metadataAddons]])
-  )
+  const out = combinations.map((options) =>  {
+    const mergedOptions = [...options, ...metadataAddons]
+
+    // Use the iterator directly to grab each pair
+    const comboIterator = mergedOptions[Symbol.iterator]();
+    const pairCount = mergedOptions.length/2
+    let outEntry = []
+
+    for (let i = 0; i < pairCount; i++) {
+      // Assumes there's 2 more values; `Object.fromEntries` only works properly with 
+      // even-arity values, so if this is not the case things will break regardless
+      outEntry.push( [ comboIterator.next().value, comboIterator.next().value ] )
+    }
+
+    return Object.fromEntries(outEntry)
+  });
 
   return out.length ? out : [Object.fromEntries(metadataAddons)]
 }


### PR DESCRIPTION
When providing multiple transforms (eg `width` and `format`), only the initial transform was being applied.

This was due to `packages/core/src/lib/resolve-configs.ts` calling `Object.fromEntries` with an array containing all option/option names, instead of an array of arrays of key/value pairs (See [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries) for the method documentation).

This commit does some massaging, using the `options` array's Iterator directly so we can grab each pair.  The `for` loop is a little ... _traditional_ ... But I implemented a `while` loop checking for Iterator doneness first and it was worse.

(This code assumes there will always be an even number of entries in `options`, mainly because if there aren't, `Object.fromEntries` won't return anything sensible anyway.)

fixes #585.

- **Quick Checklist**

* [ X ] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ X ] I have written new tests, as applicable (for bug fixes / features)
* [ X ] Docs have been added / updated (for bug fixes / features)
* [ N/A ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?**
Bug fix

- **What is the new behavior (if this is a feature change)?**
N/A

- **Does this PR introduce a breaking change?**
No