### PR TITLE
fix: address regression in resolve-configs

### DIFF
--- a/.changeset/giant-rabbits-tan.md
+++ b/.changeset/giant-rabbits-tan.md
@@ -1,0 +1,5 @@
+---
+'imagetools-core': patch
+---
+
+fix: address regression in resolve-configs

--- a/packages/core/src/__tests__/generate-configs.spec.ts
+++ b/packages/core/src/__tests__/generate-configs.spec.ts
@@ -98,6 +98,48 @@ describe('generateConfigs', () => {
     }
   })
 
+  test('the returned array contains the product of all arguments', () =>{
+    {
+      const e: [string, string[]][] = [
+        ['width', ['300', '400']],
+        ['test', ['foo', 'bar']]
+      ]
+
+      const expected = [
+        { width: '300', test: 'foo'},
+        { width: '300', test: 'bar'},
+        { width: '400', test: 'foo'},
+        { width: '300', test: 'bar'},
+      ]
+
+      const res = resolveConfigs(e, builtinOutputFormats)
+
+      expected.forEach(entry => {expect(res).toContainEqual(entry)})
+    }
+    {
+      const e: [string, string[]][] = [
+        ['width', ['300', '400']],
+        ['test', ['foo', 'bar']],
+        ['height', ['100', '700']]
+      ]
+
+      const expected = [
+        { width: '300', test: 'foo', height: '100'},
+        { width: '300', test: 'foo', height: '700'},
+        { width: '300', test: 'bar', height: '100'},
+        { width: '300', test: 'bar', height: '700'},
+        { width: '400', test: 'foo', height: '100'},
+        { width: '400', test: 'foo', height: '700'},
+        { width: '400', test: 'bar', height: '100'},
+        { width: '400', test: 'bar', height: '700'},
+      ]
+
+      const res = resolveConfigs(e, builtinOutputFormats)
+
+      expected.forEach(entry => {expect(res).toContainEqual(entry)})
+    }
+  })
+
   test('output transforms are ignored', () => {
     const e: [string, string[]][] = [
       ['width', ['300', '400']],

--- a/packages/core/src/lib/resolve-configs.ts
+++ b/packages/core/src/lib/resolve-configs.ts
@@ -4,7 +4,7 @@ import { OutputFormat } from '../index.js'
  * This function calculates the cartesian product of two or more arrays and is straight from stackoverflow ;)
  * Should be replaced with something more legible but works for now.
  */
-const cartesian = (...a: [string, string][][]) =>
+const cartesian = (...a: [[string, string]][][]) =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   a.reduce((a: any, b: any) => a.flatMap((d: any) => b.map((e: any) => [d, e].flat())))
 
@@ -21,7 +21,7 @@ export function resolveConfigs(
   // create a new array of entries for each argument
   const singleArgumentEntries = entries
     .filter(([k]) => !(k in outputFormats))
-    .map(([key, values]) => values.map<[string, string]>((v) => [key, v]))
+    .map(([key, values]) => values.map<[[string, string]]>((v) => [[key, v]]))
 
   // do a cartesian product on all entries to get all combinations we need to produce
   const combinations = singleArgumentEntries
@@ -32,7 +32,7 @@ export function resolveConfigs(
 
   // and return as an array of objects
   const out: Record<string, string | string[]>[] = combinations.map((options) =>
-    Object.fromEntries([[...options, ...metadataAddons]])
+    Object.fromEntries([...options, ...metadataAddons])
   )
 
   return out.length ? out : [Object.fromEntries(metadataAddons)]


### PR DESCRIPTION
reverting a change from https://github.com/JonasKruckenberg/imagetools/pull/583 and adding a test to prevent future regressions. thank you to @DylanLacey for the test