### PR TITLE
fix: correct detection for Vite build vs serve mode

### DIFF
--- a/.changeset/loud-penguins-nail.md
+++ b/.changeset/loud-penguins-nail.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: correct detection for Vite build vs serve mode

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -110,7 +110,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         const { transforms } = generateTransforms(config, transformFactories, srcURL.searchParams, logger)
         const { image, metadata } = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)
 
-        if (this.meta.watchMode) {
+        if (viteConfig.command === 'serve') {
           const id = generateImageID(srcURL, config)
           generatedImages.set(id, image)
           metadata.src = basePath + id


### PR DESCRIPTION
- **Quick Checklist**

* [X] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [X] I have written new tests, as applicable (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)
* [X] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix a bug where `vite build -w` produces `/@imagetools/*` URLs, when it should be producing image outputs.

- **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

- **Other information**:
