### PR TITLE
chore: generate image IDs from relative filepath

### DIFF
--- a/.changeset/tender-jobs-double.md
+++ b/.changeset/tender-jobs-double.md
@@ -2,4 +2,4 @@
 'imagetools-core': patch
 ---
 
-Image IDs are now generated from relative filepaths instead of absolute ones.
+chore: image IDs are now generated from relative filepaths instead of absolute ones

--- a/.changeset/tender-jobs-double.md
+++ b/.changeset/tender-jobs-double.md
@@ -1,0 +1,5 @@
+---
+'imagetools-core': major
+---
+
+Image IDs are now generated from relative filepaths instead of absolute ones.

--- a/.changeset/tender-jobs-double.md
+++ b/.changeset/tender-jobs-double.md
@@ -1,5 +1,5 @@
 ---
-'imagetools-core': major
+'imagetools-core': patch
 ---
 
 Image IDs are now generated from relative filepaths instead of absolute ones.

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
+import path from 'node:path'
 import sharp from 'sharp'
 import { ImageConfig } from './types.js'
-import path from 'path'
 
 export function loadImage(path: string) {
   return sharp(path)

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -9,6 +9,7 @@ export function loadImage(path: string) {
 
 export function generateImageID(url: URL, config: ImageConfig) {
   // this isn't a valid URL, but just a string used for an identifier
+  // use a relative path in the local case so that it's consistent across machines
   const baseURL = url.host
     ? new URL(url.origin + url.pathname)
     : new URL(url.protocol + path.relative(process.cwd(), url.pathname))

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -10,6 +10,7 @@ export function loadImage(path: string) {
 export function generateImageID(url: URL, config: ImageConfig) {
   const baseURL = url.host
     ? new URL(url.origin + url.pathname)
+    // use a relative path here so that the path is the same locally and on CI
     : new URL(url.protocol + path.relative(process.cwd(), url.pathname))
 
   return createHash('sha1').update(baseURL.href).update(JSON.stringify(config)).digest('hex')

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -8,6 +8,7 @@ export function loadImage(path: string) {
 }
 
 export function generateImageID(url: URL, config: ImageConfig) {
+  // this isn't a valid URL, but just a string used for an identifier
   const baseURL = url.host
     ? new URL(url.origin + url.pathname)
     // use a relative path here so that the path is the same locally and on CI

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -11,7 +11,6 @@ export function generateImageID(url: URL, config: ImageConfig) {
   // this isn't a valid URL, but just a string used for an identifier
   const baseURL = url.host
     ? new URL(url.origin + url.pathname)
-    // use a relative path here so that the path is the same locally and on CI
     : new URL(url.protocol + path.relative(process.cwd(), url.pathname))
 
   return createHash('sha1').update(baseURL.href).update(JSON.stringify(config)).digest('hex')

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,13 +1,16 @@
 import { createHash } from 'node:crypto'
 import sharp from 'sharp'
 import { ImageConfig } from './types.js'
+import path from 'path'
 
 export function loadImage(path: string) {
   return sharp(path)
 }
 
 export function generateImageID(url: URL, config: ImageConfig) {
-  const baseURL = url.host ? new URL(url.origin + url.pathname) : new URL(url.protocol + url.pathname)
+  const baseURL = url.host
+    ? new URL(url.origin + url.pathname)
+    : new URL(url.protocol + path.relative(process.cwd(), url.pathname))
 
   return createHash('sha1').update(baseURL.href).update(JSON.stringify(config)).digest('hex')
 }


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix in order to ensure that generated image IDs are consistent across environments.

- **What is the new behavior (if this is a feature change)?**

Image IDs are now generated from a relative file path instead of an absolute one which should ensure their consistency across environments.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

Yes. Generated image IDs will change so tests which rely on these IDs may break.

- **Other information**:
