### PR TITLE
feat: make image metadata available in `defaultDirectives`

### DIFF
--- a/.changeset/kind-dogs-walk.md
+++ b/.changeset/kind-dogs-walk.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': minor
+---
+
+feat: make image metadata available in defaultDirectives

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -42,7 +42,9 @@ export interface VitePluginOptions {
    * })
    * ```
    */
-  defaultDirectives?: URLSearchParams | ((url: URL, metadata: () => MaybePromise<Metadata>) => MaybePromise<URLSearchParams>)
+  defaultDirectives?:
+    | URLSearchParams
+    | ((url: URL, metadata: () => MaybePromise<Metadata>) => MaybePromise<URLSearchParams>)
 
   /**
    * You can use this option to extend the builtin list of import transforms.

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -1,4 +1,7 @@
-import { TransformFactory, OutputFormat, resolveConfigs } from 'imagetools-core'
+import type { TransformFactory, OutputFormat, resolveConfigs } from 'imagetools-core'
+import type { Metadata } from 'sharp'
+
+type MaybePromise<T> = T | Promise<T>
 
 export interface VitePluginOptions {
   /**
@@ -39,7 +42,7 @@ export interface VitePluginOptions {
    * })
    * ```
    */
-  defaultDirectives?: URLSearchParams | ((url: URL) => URLSearchParams)
+  defaultDirectives?: URLSearchParams | ((url: URL, metadata: () => MaybePromise<Metadata>) => MaybePromise<URLSearchParams>)
 
   /**
    * You can use this option to extend the builtin list of import transforms.


### PR DESCRIPTION
If you want to implement [the fancy `sizes` support that Next.js has](https://nextjs.org/docs/pages/api-reference/components/image#sizes), then you need to know the original image width in order to decide what variants to generate