### PR TITLE
fix: actually expose recently added types

### DIFF
--- a/.changeset/afraid-news-trade.md
+++ b/.changeset/afraid-news-trade.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: actually expose recently added types

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -21,6 +21,16 @@ import type { Metadata, Sharp } from 'sharp'
 import { createBasePath } from './utils.js'
 import type { VitePluginOptions } from './types.js'
 
+export type {
+  Include,
+  Exclude,
+  DefaultDirectives,
+  ExtendTransforms,
+  ExtendOutputFormats,
+  ResolveConfigs,
+  VitePluginOptions
+} from './types.js'
+
 const defaultOptions: VitePluginOptions = {
   include: /^[^?]+\.(heic|heif|avif|jpeg|jpg|png|tiff|webp|gif)(\?.*)?$/,
   exclude: 'public/**/*',


### PR DESCRIPTION
I forgot that the `types.ts` file isn't actually used for the types. Maybe we should rename it `internal.ts` or something