### PR TITLE
fix: avoid duplicate widths in output

### DIFF
--- a/.changeset/orange-actors-double.md
+++ b/.changeset/orange-actors-double.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: avoid duplicate widths in output

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -97,21 +97,17 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       const heightParam = directives.get('h')
       if (directives.get('allowUpscale') !== 'true' && (widthParam || heightParam)) {
         const metadata = await lazyLoadMetadata()
+        const clamp = (s: string, intrinsic: number) =>
+          [...new Set(s.split(';').map((d): string => (parseInt(d) <= intrinsic ? d : intrinsic.toString())))].join(';')
 
         if (widthParam) {
           const intrinsicWidth = metadata.width || 0
-          const widths = [
-            ...new Set(widthParam.split(';').map((d) => (parseInt(d) <= intrinsicWidth ? d : intrinsicWidth)))
-          ]
-          directives.set('w', widths.join(';'))
+          directives.set('w', clamp(widthParam, intrinsicWidth))
         }
 
         if (heightParam) {
           const intrinsicHeight = metadata.height || 0
-          const heights = [
-            ...new Set(heightParam.split(';').map((d) => (parseInt(d) <= intrinsicHeight ? d : intrinsicHeight)))
-          ]
-          directives.set('h', heights.join(';'))
+          directives.set('h', clamp(heightParam, intrinsicHeight))
         }
       }
 


### PR DESCRIPTION
had a `string` and `number` so they didn't get deduped. make everything a `string` when adding to the `Set`