### PR TITLE
fix: avoid using fs/promises

### DIFF
--- a/.changeset/shaggy-otters-talk.md
+++ b/.changeset/shaggy-otters-talk.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: avoid using fs/promises

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
-import { stat } from 'node:fs/promises'
+import { statSync } from 'node:fs'
 import type { ImageConfig } from 'imagetools-core'
 import type { Sharp } from 'sharp'
 
@@ -18,7 +18,7 @@ export async function generateImageID(url: URL, config: ImageConfig, originalIma
   // baseURL isn't a valid URL, but just a string used for an identifier
   // use a relative path in the local case so that it's consistent across machines
   const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  const { mtime } = await stat(path.resolve(process.cwd(), url.pathname))
+  const { mtime } = statSync(path.resolve(process.cwd(), url.pathname))
   return hash([baseURL.href, JSON.stringify(config), mtime.getTime().toString()])
 }
 


### PR DESCRIPTION
It might be less reliable since it's newer? (example: https://github.com/nodejs/node/issues/51031)

People are reporting weird errors (https://github.com/sveltejs/kit/discussions/11098) and this is my best guess at the moment