### PR TITLE
fix: use URI-decoded pathname when emitting file

### DIFF
--- a/.changeset/afraid-books-notice.md
+++ b/.changeset/afraid-books-notice.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: use URI-decoded pathname when emitting file

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -64,13 +64,14 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       if (!filter(id)) return null
 
       const srcURL = parseURL(id)
+      const pathname = decodeURIComponent(srcURL.pathname)
 
       // lazy loaders so that we can load the metadata in defaultDirectives if needed
       // but if there are no directives then we can just skip loading
       let lazyImg: Sharp
       const lazyLoadImage = () => {
         if (lazyImg) return lazyImg
-        return (lazyImg = sharp(decodeURIComponent(srcURL.pathname)))
+        return (lazyImg = sharp(pathname))
       }
 
       let lazyMetadata: Metadata
@@ -131,7 +132,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           metadata.src = basePath + id
         } else {
           const fileHandle = this.emitFile({
-            name: basename(srcURL.pathname, extname(srcURL.pathname)) + `.${metadata.format}`,
+            name: basename(pathname, extname(pathname)) + `.${metadata.format}`,
             source: await image.toBuffer(),
             type: 'asset'
           })


### PR DESCRIPTION
- **Quick Checklist**

* [*] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [*] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the new behavior (if this is a feature change)?**
Transformed images will be written to the file system without URL-encoding, just like the original files. 

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

- **Other information**:
