### PR TITLE
Add vite `origin` support for image urls in development

### DIFF
--- a/.changeset/quiet-bulldogs-appear.md
+++ b/.changeset/quiet-bulldogs-appear.md
@@ -1,0 +1,5 @@
+---
+"vite-imagetools": patch
+---
+
+Support Vite's `server.origin` option

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -128,7 +128,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         if (viteConfig.command === 'serve') {
           const id = await generateImageID(srcURL, config, img)
           generatedImages.set(id, image)
-          metadata.src = basePath + id
+          metadata.src = path.join(viteConfig?.server?.origin ?? viteConfig?.origin ?? '', basePath) + id;
         } else {
           const fileHandle = this.emitFile({
             name: basename(srcURL.pathname, extname(srcURL.pathname)) + `.${metadata.format}`,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -128,7 +128,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         if (viteConfig.command === 'serve') {
           const id = await generateImageID(srcURL, config, img)
           generatedImages.set(id, image)
-          metadata.src = path.join(viteConfig?.server?.origin ?? '', basePath) + id;
+          metadata.src = path.posix.join(viteConfig?.server?.origin ?? '', basePath) + id;
         } else {
           const fileHandle = this.emitFile({
             name: basename(srcURL.pathname, extname(srcURL.pathname)) + `.${metadata.format}`,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -128,7 +128,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         if (viteConfig.command === 'serve') {
           const id = await generateImageID(srcURL, config, img)
           generatedImages.set(id, image)
-          metadata.src = path.join(viteConfig?.server?.origin ?? viteConfig?.origin ?? '', basePath) + id;
+          metadata.src = path.join(viteConfig?.server?.origin ?? '', basePath) + id;
         } else {
           const fileHandle = this.emitFile({
             name: basename(srcURL.pathname, extname(srcURL.pathname)) + `.${metadata.format}`,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -128,7 +128,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
         if (viteConfig.command === 'serve') {
           const id = await generateImageID(srcURL, config, img)
           generatedImages.set(id, image)
-          metadata.src = path.posix.join(viteConfig?.server?.origin ?? '', basePath) + id;
+          metadata.src = path.posix.join(viteConfig?.server?.origin ?? '', basePath) + id
         } else {
           const fileHandle = this.emitFile({
             name: basename(srcURL.pathname, extname(srcURL.pathname)) + `.${metadata.format}`,


### PR DESCRIPTION
Fixes: https://github.com/JonasKruckenberg/imagetools/issues/568

Add vite `origin` support for image urls in development.