### PR TITLE
fix: avif format

### DIFF
--- a/.changeset/long-baboons-dream.md
+++ b/.changeset/long-baboons-dream.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: avif format when file is from cache

--- a/.changeset/long-baboons-dream.md
+++ b/.changeset/long-baboons-dream.md
@@ -2,4 +2,4 @@
 'vite-imagetools': patch
 ---
 
-fix: avif format when file is from cache
+fix: correctly set avif format when file is read from cache

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -523,6 +523,41 @@ describe('vite-imagetools', () => {
         expect(image).toBeTypeOf('string')
       })
     })
+
+    describe('cache.avifFormat', () => {
+      test('is avif format', async () => {
+        const dir = './node_modules/.cache/imagetools_test_cache_dir'
+        await build({
+          root: join(__dirname, '__fixtures__'),
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./pexels-allec-gomes-5195763.png?format=avif"
+                            window.__IMAGE__ = Image
+                        `),
+            imagetools({ cache: { dir } })
+          ]
+        })
+
+        const bundle = (await build({
+          root: join(__dirname, '__fixtures__'),
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./pexels-allec-gomes-5195763.png?format=avif"
+                            window.__IMAGE__ = Image
+                        `),
+            imagetools({ cache: { dir } })
+          ]
+        })) as RollupOutput | RollupOutput[]
+
+        const files = getFiles(bundle, '**.avif') as OutputAsset[]
+
+        expect(files).toHaveLength(1)
+      })
+    })
   })
 
   test('relative import', async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -142,6 +142,11 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
         if (cacheOptions.enabled && (statSync(`${cacheOptions.dir}/${id}`, { throwIfNoEntry: false })?.size ?? 0) > 0) {
           metadata = (await sharp(`${cacheOptions.dir}/${id}`).metadata()) as ImageMetadata
+          // we set the format on the metadata during transformation using the format directive
+          // when restoring from the cache, we use sharp to read it from the image and that results in a different value for avif images
+          // see https://github.com/lovell/sharp/issues/2504 and https://github.com/lovell/sharp/issues/3746
+          if (config.format === 'avif' && metadata.format === 'heif' && metadata.compression === 'av1')
+            metadata.format = 'avif'
         } else {
           const { transforms } = generateTransforms(config, transformFactories, srcURL.searchParams, logger)
           const res = await applyTransforms(transforms, img, pluginOptions.removeMetadata)


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the new behavior (if this is a feature change)?**
`avif` files that are from the cache directory have the correct format

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
No

- **Other information**:
Currently when an `avif` file read from cache, Sharp metadata returns `{format: 'heif', compression: 'av1'...}` causing the file extension and Picture mime type to be incorrect.
https://github.com/lovell/sharp/issues/2504 
https://github.com/lovell/sharp/issues/3746

The new test for `cache.avifFormat` will fail on imagetools@7.0.0
