### PR TITLE
fix: Consistent image ID hashes across machines

### DIFF
--- a/.changeset/breezy-melons-wave.md
+++ b/.changeset/breezy-melons-wave.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: consistent image id hashes across machines

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -526,7 +526,7 @@ describe('vite-imagetools', () => {
       test('is consistent', async () => {
         const image = (await readdir(dir))[0]
 
-        expect(image).toBe('7a7bca50a264376853d5c77aba0bddc0163c02f9')
+        expect(image).toBe('325b80fade286c672ea884b87e65f7a3278a9f8a')
       })
     })
 

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -502,8 +502,8 @@ describe('vite-imagetools', () => {
     })
 
     describe('cache.dir', () => {
+      const dir = './node_modules/.cache/imagetools_test_cache_dir'
       test('is used', async () => {
-        const dir = './node_modules/.cache/imagetools_test_cache_dir'
         await rm(dir, { recursive: true, force: true })
         const root = join(__dirname, '__fixtures__')
         await build({
@@ -521,6 +521,12 @@ describe('vite-imagetools', () => {
 
         const image = (await readdir(dir))[0]
         expect(image).toBeTypeOf('string')
+      })
+
+      test('is consistent', async () => {
+        const image = (await readdir(dir))[0]
+
+        expect(image).toBe('3884ad0a2b86439bb0abda8c08ee68e9fbee7c43')
       })
     })
 

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -526,7 +526,7 @@ describe('vite-imagetools', () => {
       test('is consistent', async () => {
         const image = (await readdir(dir))[0]
 
-        expect(image).toBe('e88de4c0f4a1a99e1674825722c51afca1bdc51f')
+        expect(image).toBe('b4ddbd3e7ccbad6ec1ecb43ec83523e7f3cfe3b0')
       })
     })
 

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -526,7 +526,7 @@ describe('vite-imagetools', () => {
       test('is consistent', async () => {
         const image = (await readdir(dir))[0]
 
-        expect(image).toBe('32832663b21d26da61d880b4909edd37a9dbd853')
+        expect(image).toBe('7a7bca50a264376853d5c77aba0bddc0163c02f9')
       })
     })
 

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -526,7 +526,7 @@ describe('vite-imagetools', () => {
       test('is consistent', async () => {
         const image = (await readdir(dir))[0]
 
-        expect(image).toBe('b4ddbd3e7ccbad6ec1ecb43ec83523e7f3cfe3b0')
+        expect(image).toBe('32832663b21d26da61d880b4909edd37a9dbd853')
       })
     })
 

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -526,7 +526,7 @@ describe('vite-imagetools', () => {
       test('is consistent', async () => {
         const image = (await readdir(dir))[0]
 
-        expect(image).toBe('3884ad0a2b86439bb0abda8c08ee68e9fbee7c43')
+        expect(image).toBe('e88de4c0f4a1a99e1674825722c51afca1bdc51f')
       })
     })
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -135,8 +135,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
       const imageBuffer = await img.clone().toBuffer()
 
+      const imageHash = hash([imageBuffer])
       for (const config of imageConfigs) {
-        const imageHash = hash([imageBuffer])
         const id = generateImageID(srcURL, config, imageHash)
         let image: Sharp | undefined
         let metadata: ImageMetadata

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -136,7 +136,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       const imageBuffer = await img.clone().toBuffer()
 
       for (const config of imageConfigs) {
-        const id = await generateImageID(srcURL, config, imageBuffer)
+        const id = generateImageID(srcURL, config, imageBuffer)
         let image: Sharp | undefined
         let metadata: ImageMetadata
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -137,7 +137,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
       const imageHash = hash([imageBuffer])
       for (const config of imageConfigs) {
-        const id = generateImageID(srcURL, config, imageHash)
+        const id = generateImageID(config, imageHash)
         let image: Sharp | undefined
         let metadata: ImageMetadata
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from 'imagetools-core'
 import { createFilter, dataToEsm } from '@rollup/pluginutils'
 import sharp, { type Metadata, type Sharp } from 'sharp'
-import { createBasePath, generateImageID } from './utils.js'
+import { createBasePath, generateImageID, hash } from './utils.js'
 import type { VitePluginOptions } from './types.js'
 
 export type {
@@ -136,7 +136,8 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
       const imageBuffer = await img.clone().toBuffer()
 
       for (const config of imageConfigs) {
-        const id = generateImageID(srcURL, config, imageBuffer)
+        const imageHash = hash([imageBuffer])
+        const id = generateImageID(srcURL, config, imageHash)
         let image: Sharp | undefined
         let metadata: ImageMetadata
 

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
-import { statSync } from 'node:fs'
 import type { ImageConfig } from 'imagetools-core'
 
 export const createBasePath = (base?: string) => {
@@ -16,8 +15,7 @@ export async function generateImageID(url: URL, config: ImageConfig, imageBuffer
   // baseURL isn't a valid URL, but just a string used for an identifier
   // use a relative path in the local case so that it's consistent across machines
   const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  const { size } = statSync(path.resolve(process.cwd(), decodeURIComponent(url.pathname)))
-  return hash([baseURL.href, JSON.stringify(config), size.toString()])
+  return hash([baseURL.href, JSON.stringify(config), imageBuffer])
 }
 
 function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
+import { statSync } from 'node:fs'
 import type { ImageConfig } from 'imagetools-core'
 
 export const createBasePath = (base?: string) => {
@@ -15,7 +16,8 @@ export async function generateImageID(url: URL, config: ImageConfig, imageBuffer
   // baseURL isn't a valid URL, but just a string used for an identifier
   // use a relative path in the local case so that it's consistent across machines
   const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  return hash([baseURL.href, JSON.stringify(config)])
+  const { size } = statSync(path.resolve(process.cwd(), decodeURIComponent(url.pathname)))
+  return hash([baseURL.href, JSON.stringify(config), size.toString()])
 }
 
 function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -6,7 +6,7 @@ export const createBasePath = (base?: string) => {
   return (base?.replace(/\/$/, '') || '') + '/@imagetools/'
 }
 
-export async function generateImageID(url: URL, config: ImageConfig, imageBuffer: Buffer) {
+export function generateImageID(url: URL, config: ImageConfig, imageBuffer: Buffer) {
   if (url.host) {
     const baseURL = new URL(url.origin + url.pathname)
     return hash([baseURL.href, JSON.stringify(config), imageBuffer])

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,21 +1,12 @@
 import { createHash } from 'node:crypto'
-import path from 'node:path'
 import type { ImageConfig } from 'imagetools-core'
 
 export const createBasePath = (base?: string) => {
   return (base?.replace(/\/$/, '') || '') + '/@imagetools/'
 }
 
-export function generateImageID(url: URL, config: ImageConfig, imageHash: string) {
-  if (url.host) {
-    const baseURL = new URL(url.origin + url.pathname)
-    return hash([baseURL.href, JSON.stringify(config), imageHash])
-  }
-
-  // baseURL isn't a valid URL, but just a string used for an identifier
-  // use a relative path in the local case so that it's consistent across machines
-  const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  return hash([baseURL.href, JSON.stringify(config), imageHash])
+export function generateImageID(config: ImageConfig, imageHash: string) {
+  return hash([JSON.stringify(config), imageHash])
 }
 
 export function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
-import { statSync } from 'node:fs'
 import type { ImageConfig } from 'imagetools-core'
 
 export const createBasePath = (base?: string) => {
@@ -16,8 +15,7 @@ export async function generateImageID(url: URL, config: ImageConfig, imageBuffer
   // baseURL isn't a valid URL, but just a string used for an identifier
   // use a relative path in the local case so that it's consistent across machines
   const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  const { mtime } = statSync(path.resolve(process.cwd(), decodeURIComponent(url.pathname)))
-  return hash([baseURL.href, JSON.stringify(config), mtime.getTime().toString()])
+  return hash([baseURL.href, JSON.stringify(config)])
 }
 
 function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -6,19 +6,19 @@ export const createBasePath = (base?: string) => {
   return (base?.replace(/\/$/, '') || '') + '/@imagetools/'
 }
 
-export function generateImageID(url: URL, config: ImageConfig, imageBuffer: Buffer) {
+export function generateImageID(url: URL, config: ImageConfig, imageHash: string) {
   if (url.host) {
     const baseURL = new URL(url.origin + url.pathname)
-    return hash([baseURL.href, JSON.stringify(config), imageBuffer])
+    return hash([baseURL.href, JSON.stringify(config), imageHash])
   }
 
   // baseURL isn't a valid URL, but just a string used for an identifier
   // use a relative path in the local case so that it's consistent across machines
   const baseURL = new URL(url.protocol + path.relative(process.cwd(), url.pathname))
-  return hash([baseURL.href, JSON.stringify(config), imageBuffer])
+  return hash([baseURL.href, JSON.stringify(config), imageHash])
 }
 
-function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {
+export function hash(keyParts: Array<string | NodeJS.ArrayBufferView>) {
   let hash = createHash('sha1')
   for (const keyPart of keyParts) {
     hash = hash.update(keyPart)


### PR DESCRIPTION
This PR fixes an issue that we've been experiencing in https://github.com/huntabyte/shadcn-svelte/pull/978 where the hash for the generated image ID is different when it's computed on different machines. The goal of that PR was to cache the images so that they can be utilized across our GH runners.

The source of the issue is the `mtime` stat from the image file, which seemingly differs from machine to machine, causing the hash to generate a different id, resulting in a cache MISS. Instead, `mtime` has been replaced for the `size` stat, which (in conjunction with the image config and file url) should provide sufficient uniqueness for the hash.

---

- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
	Bug fix

- **What is the new behavior (if this is a feature change)?**
	Implements consistent image ID hashing across machines	

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
	No

- **Other information**:
	I wasn't sure the best way to express this change in a test, so I've hardcoded the expected id string. I'm sure there's a better way to do it, so please feel free to modify it!