### PR TITLE
fix: clone image before apply transforms

### DIFF
--- a/.changeset/brown-dragons-walk.md
+++ b/.changeset/brown-dragons-walk.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: clone image before apply transform

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -150,7 +150,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             metadata.format = 'avif'
         } else {
           const { transforms } = generateTransforms(config, transformFactories, srcURL.searchParams, logger)
-          const res = await applyTransforms(transforms, img, pluginOptions.removeMetadata)
+          const res = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)
           metadata = res.metadata
           if (cacheOptions.enabled) {
             await writeFile(`${cacheOptions.dir}/${id}`, await res.image.toBuffer())


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the new behavior (if this is a feature change)?**
Clone image before apply transforms
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

- **Other information**:
Images should be cloned before apply transforms, otherwise the new config will overwrite the previous operation when starting apply transforms