### PR TITLE
feat: add experimental image orientation fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "dev": "rollup -cw",
     "build": "rollup -c",
     "test": "vitest run",
+    "test:watch": "vitest watch",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-1.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a454c73fa784fc12c87dcd7e427dc69898fbd6f74af29546e6877feca534e9
+size 5958

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-2.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b27966033202c487f07d78fc3ea8e443eab7256d6a27a40ca33ca39081b0ab1
+size 6314

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-3.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c67163065e5f7e376efeb8e853f08c3596448341a73fc6bb2ecd07b1c355a3
+size 6526

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-4.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3480b1d2152d69fc1a73e2afc752e4d18a37a7228d0fce65fa6430e1ad310f7f
+size 6279

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-5.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1672b6b3c3ba64b38c9378b21f9469cc9755f19883aa87efa71878be43fe8afd
+size 6135

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-6.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4686682b11ae4c95fd3a496d5aa0086948374c3157abce0806dbedb75a13014
+size 6123

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-7.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ed3fa70a7d765be3005458863e428d8e0ab694424832b7317c2e5ab785f9e1
+size 6296

--- a/packages/core/src/__tests__/__fixtures__/exif-orientation-8.jpg
+++ b/packages/core/src/__tests__/__fixtures__/exif-orientation-8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45d931fe64586047a88f0d450e827e8e3afbecbe8b3882bc48e43236341c162d
+size 6242

--- a/packages/core/src/__tests__/apply-transforms.spec.ts
+++ b/packages/core/src/__tests__/apply-transforms.spec.ts
@@ -30,10 +30,20 @@ describe('applyTransforms', () => {
     expect(metadata).not.toHaveProperty('iptc')
   })
 
-  it('metadata stripping can be disabled', async () => {
+  it('metadata stripping can be disabled via boolean', async () => {
     const t = vi.fn((i) => i)
 
     const { metadata } = await applyTransforms([t], img, false)
+
+    expect(t).toBeCalled()
+    expect(metadata).toHaveProperty('icc')
+    expect(metadata).toHaveProperty('xmp')
+  })
+
+  it('metadata stripping can be disabled via options object', async () => {
+    const t = vi.fn((i) => i)
+
+    const { metadata } = await applyTransforms([t], img, { removeMetadata: false })
 
     expect(t).toBeCalled()
     expect(metadata).toHaveProperty('icc')

--- a/packages/core/src/lib/apply-transforms.ts
+++ b/packages/core/src/lib/apply-transforms.ts
@@ -1,15 +1,36 @@
 import type { Sharp } from 'sharp'
-import type { ImageTransformation, TransformResult } from '../types.js'
+import type { ApplyTransformsOptions, ImageTransformation, TransformResult } from '../types.js'
 import { METADATA } from './metadata.js'
+
+const defaultOptions: ApplyTransformsOptions = {
+  removeMetadata: true
+}
 
 export async function applyTransforms(
   transforms: ImageTransformation[],
   image: Sharp,
-  removeMetadata = true
+  options?: ApplyTransformsOptions
+): Promise<TransformResult>
+export async function applyTransforms(
+  transforms: ImageTransformation[],
+  image: Sharp,
+  removeMetadata?: boolean
+): Promise<TransformResult>
+export async function applyTransforms(
+  transforms: ImageTransformation[],
+  image: Sharp,
+  optionsOrRemoveMetadata?: ApplyTransformsOptions | boolean
 ): Promise<TransformResult> {
+  const opts = {
+    ...defaultOptions,
+    ...(typeof optionsOrRemoveMetadata === 'boolean'
+      ? { removeMetadata: optionsOrRemoveMetadata }
+      : optionsOrRemoveMetadata)
+  }
+
   image[METADATA] = { ...(await image.metadata()) }
 
-  if (removeMetadata) {
+  if (opts.removeMetadata) {
     // delete the private metadata
     delete image[METADATA].exif
     delete image[METADATA].iptc

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f93465af3b7d77b4236dc2e942576c397db949bc0da3d724bf10777c12baaf
+size 11034

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f93465af3b7d77b4236dc2e942576c397db949bc0da3d724bf10777c12baaf
+size 11034

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f93465af3b7d77b4236dc2e942576c397db949bc0da3d724bf10777c12baaf
+size 11034

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f93465af3b7d77b4236dc2e942576c397db949bc0da3d724bf10777c12baaf
+size 11034

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b081805bf9b1afe41f66f57357c70b695ec849fa931c8154336f4bbf0fd529f
+size 10511

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b081805bf9b1afe41f66f57357c70b695ec849fa931c8154336f4bbf0fd529f
+size 10511

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b081805bf9b1afe41f66f57357c70b695ec849fa931c8154336f4bbf0fd529f
+size 10511

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-1-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b081805bf9b1afe41f66f57357c70b695ec849fa931c8154336f4bbf0fd529f
+size 10511

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d65ffdf231dc9f3c1829a04b804136ec75c548eabae291a05002107251cbacb4
+size 16655

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d65ffdf231dc9f3c1829a04b804136ec75c548eabae291a05002107251cbacb4
+size 16655

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5be20224282f4dc20528092b47449bb8152ae1a62d02dab5dc23e87f98574be4
+size 11862

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5be20224282f4dc20528092b47449bb8152ae1a62d02dab5dc23e87f98574be4
+size 11862

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e321537df4a9825507fc5b7fdb44199027f2a654cfcfd54447c00ab31dcf8ec1
+size 16144

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e321537df4a9825507fc5b7fdb44199027f2a654cfcfd54447c00ab31dcf8ec1
+size 16144

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f86e7e31882b3239f039fa252fab40d6366b1e3d5d39bbe52fed07e152244b90
+size 11351

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-2-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f86e7e31882b3239f039fa252fab40d6366b1e3d5d39bbe52fed07e152244b90
+size 11351

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:693d1e9bd22a513fe6f8f30e9b5fcbb48cb94b61b57216643cb55e5821d9055b
+size 17426

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:693d1e9bd22a513fe6f8f30e9b5fcbb48cb94b61b57216643cb55e5821d9055b
+size 17426

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0336f9d10547194a7d4131c64aecf03a04a4f8fd1155fc91af52b792015f651
+size 12600

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0336f9d10547194a7d4131c64aecf03a04a4f8fd1155fc91af52b792015f651
+size 12600

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fb5c2f130978f451b668888b2d379c46df686831fcb8ca37489f031939c32a7
+size 16915

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fb5c2f130978f451b668888b2d379c46df686831fcb8ca37489f031939c32a7
+size 16915

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b719010381f58988f24c622cc311a3083aa89b1db11ae3eabc09cccefe734686
+size 12089

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-3-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b719010381f58988f24c622cc311a3083aa89b1db11ae3eabc09cccefe734686
+size 12089

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8078a0bd161fd5bf91dbd2759ce6f9f67755edb42816f97ef75b0ed3bb709a6b
+size 16700

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8078a0bd161fd5bf91dbd2759ce6f9f67755edb42816f97ef75b0ed3bb709a6b
+size 16700

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d748ebbceb9342b9d5394cf3d26869f66fc8ee691ccf918874d3fe76dbd4484e
+size 12014

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d748ebbceb9342b9d5394cf3d26869f66fc8ee691ccf918874d3fe76dbd4484e
+size 12014

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec3d1a9a1bece6c4b9eb538a9eb2ffaf5a0254b503ade22c7edf637222a171f
+size 16189

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec3d1a9a1bece6c4b9eb538a9eb2ffaf5a0254b503ade22c7edf637222a171f
+size 16189

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a73b3bfc582947e4b519487fec990ae6f50b96bc37f77d36f674eb03ca34fee
+size 11503

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-4-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a73b3bfc582947e4b519487fec990ae6f50b96bc37f77d36f674eb03ca34fee
+size 11503

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ea6e6799a958212c684b4c1ed77c8f07f47f08fd6c57ab554970c18bc7671a3
+size 16541

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ea6e6799a958212c684b4c1ed77c8f07f47f08fd6c57ab554970c18bc7671a3
+size 16541

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5920259fc4fdcded1267373018e0c20cc2e2c581004b1fa26bb7724eb8e80a87
+size 12721

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5920259fc4fdcded1267373018e0c20cc2e2c581004b1fa26bb7724eb8e80a87
+size 12721

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d6e1c67f26a5e3bf94511c267333761c9d8d54c2cec06e95c0528d23c4c05b
+size 16030

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d6e1c67f26a5e3bf94511c267333761c9d8d54c2cec06e95c0528d23c4c05b
+size 16030

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61f410e6c4e16a85e05b20e1d9e8f18bc1a1b0607ea2761a6dc9d8b8645b36c9
+size 12210

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-5-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61f410e6c4e16a85e05b20e1d9e8f18bc1a1b0607ea2761a6dc9d8b8645b36c9
+size 12210

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6aa07479821477943a0d3520458751d5e8dadbee59ca8581a085182000311b
+size 16323

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6aa07479821477943a0d3520458751d5e8dadbee59ca8581a085182000311b
+size 16323

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72543f46aaed6429dff752fdd8f5ec676aa880f55bb3d6043306087eaeb25cd5
+size 12413

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72543f46aaed6429dff752fdd8f5ec676aa880f55bb3d6043306087eaeb25cd5
+size 12413

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49f1aee610eb699d242a11092793c1947d3f8bec3cf7f55bb720dbe98741522
+size 15812

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49f1aee610eb699d242a11092793c1947d3f8bec3cf7f55bb720dbe98741522
+size 15812

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670db7417dbc8842007cccf6eb06ee6151f9ea182b5e6bbd310b776ad6b699a3
+size 11902

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flip-spec-ts-src-transforms-tests-flip-spec-ts-flip-with-orientation-6-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670db7417dbc8842007cccf6eb06ee6151f9ea182b5e6bbd310b776ad6b699a3
+size 11902

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2558f1966771ddac8a1eec2edab58b53928ed9a811a593aaea26567ef6f80773
+size 11084

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2558f1966771ddac8a1eec2edab58b53928ed9a811a593aaea26567ef6f80773
+size 11084

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2558f1966771ddac8a1eec2edab58b53928ed9a811a593aaea26567ef6f80773
+size 11084

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2558f1966771ddac8a1eec2edab58b53928ed9a811a593aaea26567ef6f80773
+size 11084

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707c224fe0d41c1692e29ef813f73eea72c257f224d6f3434ba292cd8b201dfa
+size 10561

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707c224fe0d41c1692e29ef813f73eea72c257f224d6f3434ba292cd8b201dfa
+size 10561

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707c224fe0d41c1692e29ef813f73eea72c257f224d6f3434ba292cd8b201dfa
+size 10561

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-1-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707c224fe0d41c1692e29ef813f73eea72c257f224d6f3434ba292cd8b201dfa
+size 10561

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a5b8bf34f0d261f74fe94f10652ac742dc7b4ded02c0801ac05960f4a2d1660
+size 16490

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a5b8bf34f0d261f74fe94f10652ac742dc7b4ded02c0801ac05960f4a2d1660
+size 16490

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c33a2bf78d157d93389dcdfba207cc06219a8fd272674eda2c85609f6b1650e
+size 11881

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c33a2bf78d157d93389dcdfba207cc06219a8fd272674eda2c85609f6b1650e
+size 11881

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d1c6f8b69b90b7419e47f00e34528b77b595b28dbe8e65c4595d2638980502
+size 15979

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d1c6f8b69b90b7419e47f00e34528b77b595b28dbe8e65c4595d2638980502
+size 15979

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e22e42f46d5c826fbe42b13c8d1620ceec73156798abcecda0f3679fbf0dbc
+size 11370

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-2-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e22e42f46d5c826fbe42b13c8d1620ceec73156798abcecda0f3679fbf0dbc
+size 11370

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a126ac674f3fbdfb119ee595ff15f45037055463bb5829b5315e468308888af4
+size 17280

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a126ac674f3fbdfb119ee595ff15f45037055463bb5829b5315e468308888af4
+size 17280

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4feb98d01f2c8cd1b506e5fedc82e3c65d12e3dd80d97e90761ebb8fc4b37b23
+size 12659

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4feb98d01f2c8cd1b506e5fedc82e3c65d12e3dd80d97e90761ebb8fc4b37b23
+size 12659

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:603b806117fd81044d217268d42d3376f8669f06bdfe36de3127ecda4aed9192
+size 16769

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:603b806117fd81044d217268d42d3376f8669f06bdfe36de3127ecda4aed9192
+size 16769

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dcce31ca17842512cfc0bcc1f22bdc4469cd4d8216845cea07a925b61404ae1
+size 12148

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-3-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dcce31ca17842512cfc0bcc1f22bdc4469cd4d8216845cea07a925b61404ae1
+size 12148

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e773d177dfea63e3ffac2c5dc046a3f73b0452555d5da7608a756dd708f7648
+size 16781

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e773d177dfea63e3ffac2c5dc046a3f73b0452555d5da7608a756dd708f7648
+size 16781

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7234966c19da5f9694aa2c5e3bf1bf59dc2f1bd1d92db5dae1b42188a27735b0
+size 12073

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7234966c19da5f9694aa2c5e3bf1bf59dc2f1bd1d92db5dae1b42188a27735b0
+size 12073

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:225fd75ea40800b2ab4a7395750abd97d8f8f6c49d73f4085a249bb0e4796c6d
+size 16270

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:225fd75ea40800b2ab4a7395750abd97d8f8f6c49d73f4085a249bb0e4796c6d
+size 16270

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb9bede548c7993c6eaa5fdfff905816ff6b450abf44033ee758e8604392faff
+size 11562

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-4-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb9bede548c7993c6eaa5fdfff905816ff6b450abf44033ee758e8604392faff
+size 11562

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35d354547b633347f3695c1392a9bdf59cd8f37722eb01d1523573c777af14e0
+size 16526

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35d354547b633347f3695c1392a9bdf59cd8f37722eb01d1523573c777af14e0
+size 16526

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0275b852ad5df8aa0c9b81475b1ac70ed00cec1956371199e5b4d4c6a58bbc5
+size 12735

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0275b852ad5df8aa0c9b81475b1ac70ed00cec1956371199e5b4d4c6a58bbc5
+size 12735

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b60e8f692131e517ea4764f395b708c99bd3500ffc310e4fc64160b01e7ce7a7
+size 16015

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b60e8f692131e517ea4764f395b708c99bd3500ffc310e4fc64160b01e7ce7a7
+size 16015

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e79800a097800cfdf5ae160b0fc6281d0e9877f86722870b8d8f13b4aade54f
+size 12224

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-5-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e79800a097800cfdf5ae160b0fc6281d0e9877f86722870b8d8f13b4aade54f
+size 12224

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411e0a98399b858c08aa3b3c8d1c816bbe424f9cdde3183e536a81ca3f894e43
+size 16259

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411e0a98399b858c08aa3b3c8d1c816bbe424f9cdde3183e536a81ca3f894e43
+size 16259

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32564fbb526b5f53becb76354fb9df71f2883171b8f113c7ad042cdd85e3fa1c
+size 12386

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-false-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32564fbb526b5f53becb76354fb9df71f2883171b8f113c7ad042cdd85e3fa1c
+size 12386

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-expected-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-expected-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a28d032e83ffa2fbb95258d463142a8e1a56d5ea9f7c5c9baa1413fd7a0a3260
+size 15748

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-expected-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a28d032e83ffa2fbb95258d463142a8e1a56d5ea9f7c5c9baa1413fd7a0a3260
+size 15748

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-legacy-behavior-once-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6102e2e0dda711a81403dae5d73cd21aea6269a4e5e94a5b05c826974a8513dc
+size 11875

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/flop-spec-ts-src-transforms-tests-flop-spec-ts-flop-with-orientation-6-matches-remove-metadata-true-legacy-behavior-twice-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6102e2e0dda711a81403dae5d73cd21aea6269a4e5e94a5b05c826974a8513dc
+size 11875

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53b8166ad4d2fa2ecb8326174e0e8400d4580bbbeb78c85e2e9b35e8965fa281
+size 11039

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bf700f43fd1fa0aec7c4d8c915a4d68fcda75db32e84be6b5c5a6cce10b6ee2
+size 15105

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbe13274235132a793dea305e0cf4d5b140a4180e88fa22290a32dd4e5a8f39
+size 11015

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53b8166ad4d2fa2ecb8326174e0e8400d4580bbbeb78c85e2e9b35e8965fa281
+size 11039

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bf700f43fd1fa0aec7c4d8c915a4d68fcda75db32e84be6b5c5a6cce10b6ee2
+size 15105

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbe13274235132a793dea305e0cf4d5b140a4180e88fa22290a32dd4e5a8f39
+size 11015

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37868d2cda3711c7ac023fb867150ffc787ac3ef3eece05bab3460f5c13541c6
+size 10516

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abedb2060f0fd29413c3b7ef55f31dd2d88091fe4876bbdfd46036cbdcec6495
+size 14582

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142124167e0c783b9a7484ce036fc639d8ff6776a9edac935c377a7bb1dc7c96
+size 10492

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37868d2cda3711c7ac023fb867150ffc787ac3ef3eece05bab3460f5c13541c6
+size 10516

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abedb2060f0fd29413c3b7ef55f31dd2d88091fe4876bbdfd46036cbdcec6495
+size 14582

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-1-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142124167e0c783b9a7484ce036fc639d8ff6776a9edac935c377a7bb1dc7c96
+size 10492

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02546f1f9c1be8260a8d1803dde277628ebe1507f6060d83cf9aaf335616799c
+size 16534

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d0cac22029dbfe9d8e4819150400000a2c2417f7b6d1c5652f7503789e9d9e8
+size 19873

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3618b04227f5b93fef772320573a968e88b331fe68e9e8ac12e54503daab43a
+size 16396

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f03e62cc94273c40c970f096af2e2a021282e8e079d3d847c47e348b1553198
+size 11888

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:569674da05c750c6b202e5212f78975e272b27d70cce3d7e100f99a7197fbc05
+size 15890

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7286ac18e5514de93b39ce9788601e820fde6563d5d505d9d0cf7c208110b32
+size 11733

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c134889f8192949490313389bd9edb6227f6ca5b4e9c8906db33ebbdb6e9f7b6
+size 16023

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d33cf4ccbdaf153ffa89693574e7b1682e537f8a7b822a0a9baa7b779a41b7
+size 19362

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a128909b14c11c8e050facd078a7083f6360e42f0cc2568e0a2bba2f1fd83cf
+size 15885

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45bfab03896e4af86cae94f47090e0b1a2eb8acee349f53842714475e7abb14e
+size 11377

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fb1c3a5b6b727f99c6931ba00ed3a5f4c9e0fedf433109a8f7335315fd7d5c4
+size 15379

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-2-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57d228df5b999e82995170d53018b7375e78b32abfec81cd75050ce4f4b2ebd5
+size 11222

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b501380bd1704bdf9e4e68e354f5b27c59cdb5866b6c84e744ec3196412de743
+size 16852

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7b180359c95592d6b5144b7f569a3e116fd00b492060772de31b7a61e420f9
+size 20238

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64493621cf9d17be85ae30a75f421d788938ffe12d5d79c501327f98fcfdae05
+size 16408

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52b80c208af4d6c38a56d16c0cac162be71aedd2bb574c0eb1346ed9f52daff6
+size 12617

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea12a1199652fd10a63bb00e1e0fe9f48ed0b42225d46cf3ee9e7ed6e7d76853
+size 16093

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:955a515856dd31405a7f18b0958fb7ca65af3d9b43edd01522ff0d261c5f37b3
+size 12557

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b501380bd1704bdf9e4e68e354f5b27c59cdb5866b6c84e744ec3196412de743
+size 16852

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7b180359c95592d6b5144b7f569a3e116fd00b492060772de31b7a61e420f9
+size 20238

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64493621cf9d17be85ae30a75f421d788938ffe12d5d79c501327f98fcfdae05
+size 16408

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb835d7a7a442f4af23ed519a845566f0d06c523536ea4beda8e3ce02b8aaa20
+size 12106

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d14c58da44fe8a8ae1df49961d41ee04896f1bc97c73746a9c9a987e9cf7ec3
+size 15582

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-3-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ec0e4d45ae4f47ace963c5d03574576736cebc71b1be93a24d592bf3b4b4712
+size 12046

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b86a5b6d3472f9a6c136d06332d50cd1999a6582f0529c70a556c1126d6f11c
+size 16712

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4229e1ac39420b0911eb0d1fafb4b2ab1dbfd093a7f08dcdf467e413f257e2e
+size 20139

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d95bc5d6148ba4a70bcfeba6dd2f434eb85f5c545ad70f4d17f79f4a039ae20b
+size 16365

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed583ffe5ec7f149e8d42ab1b8d29d0237191a795bf0f12bc5491292ede57c87
+size 12061

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e99e6301da6ab7a073498e0fa8216ab639d66bd25df353feed6b6b07062831d
+size 15610

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9304d7f9e0b042d477ea399f5b334f07be031f1f1ab18a00f0376eba9e6a1a5
+size 12067

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48e4150d3415380386917ea1113508dc235c2aa08096c007cd66c98e7cd82e9
+size 16201

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da861239c8761cf0cd4ecff393028746a90a1b16d9fe6781aeaee9e8532d1c7b
+size 19628

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aaba422bfdfe367d22e2b27a85f984f8fd435a40b534810a16288702b2ec628
+size 15854

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4b2e06ef3d4f2dcf76f44106207a7dddb492b04d12b53307f80ed093478326b
+size 11550

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:113ebc8cd5ce8f33cba76f03e8c54b34b5071125aaa54a09d5508e5fcef7392c
+size 15099

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-4-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984b6d03aaea8086f6a033225ed918a80525d869a22e59645fa82012bce618b5
+size 11556

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bebce8b89960d3bc2bbf5ffe86f3f1e358279dcdd5fa61a2b089b9fa9e72bd96
+size 16503

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f89078eb37f7c1114487d5351d3bd46a6c9efc46e02442ac1bfd375eedd4108
+size 19743

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae33f5300f526cea0dfbe2e8b620c4cee45993c1c9ee44f1515b5d87356c32d9
+size 16324

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c51e6e6c165019df4e717ba7fe62c0afc5aaea06eb6626db9b491393c9693393
+size 12756

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e7abf6a28dd651fcfea75b5a00b829e8023bee8fc13537a183b9bb7ca6a7104
+size 15724

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef1a76a4d9a1e4646ed090aedcc1bb572ea81ae2f371c850dd215fe36c29ff1
+size 12769

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:600ce260a271b63270746ef1494bf3e8e9a952a89ab6e13639b87b8c469953fa
+size 15992

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8f7e35f9e41acbc3113cab488d5213ecde0662c6c9e970f7b5f40f93d603965
+size 19232

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc9fef6c681c59b39994e70cdeeb7896f151ab7c057679595f64c7165699b486
+size 15813

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:088427c6e415b4da5f7403153697d8425e8ae9dac314d3cbe614ec617edbe7d9
+size 12245

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88b9e4a028fcfab6cd8857755ad1d5a5855d97241805f5ab5b887fd927bf733d
+size 15213

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-5-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9df34a9626d462ab7954f051eb5e37a0f38d72b1741fe750533160cb411b9a16
+size 12258

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c65ba7235e187e1afa421dbc91c584c26af61c4d945a015ca22c42d1207a2604
+size 15735

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e40ab53ace65beba4e4eff5ed5bd53bfd3c3edc4bdd1270e5805715d825aa9
+size 18955

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37a9ffcd02fb1a15573630f82c477b8befe706c4976a2946fde162fdf78ed280
+size 15614

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e82dc54137294e6ac8652a8a91aadcf5dc71d09f3166311d3e1916652e5ac5ca
+size 12397

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:213c06de897452e6c8ed374d993ef10b7aabf28454bd17ad97ed8fd1242fd24e
+size 15497

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-false-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd22c0b5b40d48098f0efb97a0ed1401a2f5f6bbf1461e89efad7719945c5360
+size 12454

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c65ba7235e187e1afa421dbc91c584c26af61c4d945a015ca22c42d1207a2604
+size 15735

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e40ab53ace65beba4e4eff5ed5bd53bfd3c3edc4bdd1270e5805715d825aa9
+size 18955

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-expected-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37a9ffcd02fb1a15573630f82c477b8befe706c4976a2946fde162fdf78ed280
+size 15614

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-180-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1013306c82390a1e37ea39234c1f18b805b181b9829a47d6d1d852eb9ba4714e
+size 11886

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-45-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:591496667c543837907b90998199877d8d133c016effe9ac72a715e7292e5e77
+size 14986

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/rotate-spec-ts-src-transforms-tests-rotate-spec-ts-rotate-with-orientation-6-matches-remove-metadata-true-legacy-behavior-90-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acf9385c33f9ed598739be6b48f54dcc5324699c42f060361779d81dfd08151d
+size 11943

--- a/packages/core/src/transforms/__tests__/flip.spec.ts
+++ b/packages/core/src/transforms/__tests__/flip.spec.ts
@@ -82,11 +82,19 @@ describe('flip', () => {
       const scenarios = [
         {
           name: 'matches removeMetadata=true legacy behavior',
-          opts: { removeMetadata: true }
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: false } }
         },
         {
           name: 'matches removeMetadata=false legacy behavior',
-          opts: { removeMetadata: false }
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: false } }
+        },
+        {
+          name: 'matches removeMetadata=true expected behavior',
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: true } }
+        },
+        {
+          name: 'matches removeMetadata=false expected behavior',
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: true } }
         }
       ]
 

--- a/packages/core/src/transforms/__tests__/flip.spec.ts
+++ b/packages/core/src/transforms/__tests__/flip.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { TransformFactoryContext } from '../../types'
 import { flip } from '../flip'
-import { applyTransforms } from '../../index'
+import { applyTransforms, format } from '../../index'
 import sharp, { Sharp } from 'sharp'
 import { join } from 'path'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
@@ -65,6 +65,54 @@ describe('flip', () => {
       const { image } = await applyTransforms([flip({ flip: 'true' }, dirCtx)!], img)
 
       expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+  })
+
+  const exifOrientations = [1, 2, 3, 4, 5, 6]
+
+  exifOrientations.forEach((exifOrientation) => {
+    describe(`with orientation ${exifOrientation}:`, () => {
+      let img: Sharp
+      beforeEach(() => {
+        img = sharp(join(__dirname, `../../__tests__/__fixtures__/exif-orientation-${exifOrientation}.jpg`))
+      })
+      // `.toMatchImageSnapshot` doesn't work with anything other than PNG
+      const formatTransform = format({ format: 'png' }, dirCtx)
+
+      const scenarios = [
+        {
+          name: 'matches removeMetadata=true legacy behavior',
+          opts: { removeMetadata: true }
+        },
+        {
+          name: 'matches removeMetadata=false legacy behavior',
+          opts: { removeMetadata: false }
+        }
+      ]
+
+      for (const scenario of scenarios) {
+        describe(scenario.name, () => {
+          test('once', async () => {
+            const { image } = await applyTransforms(
+              [flip({ flip: 'true' }, dirCtx)!, formatTransform!],
+              img,
+              scenario.opts
+            )
+
+            expect(await image.toBuffer()).toMatchImageSnapshot()
+          })
+
+          test('twice', async () => {
+            const { image } = await applyTransforms(
+              [flip({ flip: 'true' }, dirCtx)!, flip({ flip: 'true' }, dirCtx)!, formatTransform!],
+              img,
+              scenario.opts
+            )
+
+            expect(await image.toBuffer()).toMatchImageSnapshot()
+          })
+        })
+      }
     })
   })
 })

--- a/packages/core/src/transforms/__tests__/flop.spec.ts
+++ b/packages/core/src/transforms/__tests__/flop.spec.ts
@@ -82,11 +82,19 @@ describe('flop', () => {
       const scenarios = [
         {
           name: 'matches removeMetadata=true legacy behavior',
-          opts: { removeMetadata: true }
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: false } }
         },
         {
           name: 'matches removeMetadata=false legacy behavior',
-          opts: { removeMetadata: false }
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: false } }
+        },
+        {
+          name: 'matches removeMetadata=true expected behavior',
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: true } }
+        },
+        {
+          name: 'matches removeMetadata=false expected behavior',
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: true } }
         }
       ]
 

--- a/packages/core/src/transforms/__tests__/rotate.spec.ts
+++ b/packages/core/src/transforms/__tests__/rotate.spec.ts
@@ -90,11 +90,19 @@ describe('rotate', () => {
       const scenarios = [
         {
           name: 'matches removeMetadata=true legacy behavior',
-          opts: { removeMetadata: true }
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: false } }
         },
         {
           name: 'matches removeMetadata=false legacy behavior',
-          opts: { removeMetadata: false }
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: false } }
+        },
+        {
+          name: 'matches removeMetadata=true expected behavior',
+          opts: { removeMetadata: true, experimental: { preserveInitialOrientation: true } }
+        },
+        {
+          name: 'matches removeMetadata=false expected behavior',
+          opts: { removeMetadata: false, experimental: { preserveInitialOrientation: true } }
         }
       ]
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,10 @@ export type TransformOption<A = Record<string, unknown>, T = unknown> = (
 
 export type ImageTransformation = (image: Sharp) => Sharp | Promise<Sharp>
 
+export type ApplyTransformsOptions = {
+  removeMetadata?: boolean
+}
+
 export interface TransformResult {
   image: Sharp
   metadata: ImageMetadata

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,6 +62,9 @@ export type ImageTransformation = (image: Sharp) => Sharp | Promise<Sharp>
 
 export type ApplyTransformsOptions = {
   removeMetadata?: boolean
+  experimental?: {
+    preserveInitialOrientation?: boolean
+  }
 }
 
 export interface TransformResult {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,6 +32,7 @@
     "dev": "rollup -cw",
     "build": "rollup -c",
     "test": "vitest run",
+    "test:watch": "vitest watch",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/vite/src/__tests__/__fixtures__/exif-orientation-3.jpg
+++ b/packages/vite/src/__tests__/__fixtures__/exif-orientation-3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c67163065e5f7e376efeb8e853f08c3596448341a73fc6bb2ecd07b1c355a3
+size 6526

--- a/packages/vite/src/__tests__/__image_snapshots__/main-test-ts-src-tests-main-test-ts-vite-imagetools-options-experimental-preserve-initial-orientation-false-retains-old-behavior-1-snap.png
+++ b/packages/vite/src/__tests__/__image_snapshots__/main-test-ts-src-tests-main-test-ts-vite-imagetools-options-experimental-preserve-initial-orientation-false-retains-old-behavior-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ec0e4d45ae4f47ace963c5d03574576736cebc71b1be93a24d592bf3b4b4712
+size 12046

--- a/packages/vite/src/__tests__/__image_snapshots__/main-test-ts-src-tests-main-test-ts-vite-imagetools-options-experimental-preserve-initial-orientation-true-affects-images-with-orientation-1-snap.png
+++ b/packages/vite/src/__tests__/__image_snapshots__/main-test-ts-src-tests-main-test-ts-vite-imagetools-options-experimental-preserve-initial-orientation-true-affects-images-with-orientation-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ec0e4d45ae4f47ace963c5d03574576736cebc71b1be93a24d592bf3b4b4712
+size 12046

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -358,6 +358,48 @@ describe('vite-imagetools', () => {
       })
     })
 
+    describe('experimental.preserveInitialOrientation', () => {
+      test('true affects images with orientation', async () => {
+        const bundle = (await build({
+          root: join(__dirname, '__fixtures__'),
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./exif-orientation-3.jpg?rotate=90&format=png"
+                            window.__IMAGE__ = Image
+                        `),
+            imagetools({
+              experimental: { preserveInitialOrientation: true }
+            })
+          ]
+        })) as RollupOutput | RollupOutput[]
+
+        const files = getFiles(bundle, '**.png') as OutputAsset[]
+        expect(files[0].source).toMatchImageSnapshot()
+      })
+
+      test('false retains old behavior', async () => {
+        const bundle = (await build({
+          root: join(__dirname, '__fixtures__'),
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./exif-orientation-3.jpg?rotate=90&format=png"
+                            window.__IMAGE__ = Image
+                        `),
+            imagetools({
+              experimental: { preserveInitialOrientation: false }
+            })
+          ]
+        })) as RollupOutput | RollupOutput[]
+
+        const files = getFiles(bundle, '**.png') as OutputAsset[]
+        expect(files[0].source).toMatchImageSnapshot()
+      })
+    })
+
     describe('resolveConfigs', () => {
       test('can be used to generate multiple images (presets)', async () => {
         const bundle = (await build({

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -150,7 +150,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             metadata.format = 'avif'
         } else {
           const { transforms } = generateTransforms(config, transformFactories, srcURL.searchParams, logger)
-          const res = await applyTransforms(transforms, img, pluginOptions.removeMetadata)
+          const res = await applyTransforms(transforms, img, { removeMetadata: pluginOptions.removeMetadata })
           metadata = res.metadata
           if (cacheOptions.enabled) {
             await writeFile(`${cacheOptions.dir}/${id}`, await res.image.toBuffer())

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -150,7 +150,10 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             metadata.format = 'avif'
         } else {
           const { transforms } = generateTransforms(config, transformFactories, srcURL.searchParams, logger)
-          const res = await applyTransforms(transforms, img, { removeMetadata: pluginOptions.removeMetadata })
+          const res = await applyTransforms(transforms, img, {
+            removeMetadata: pluginOptions.removeMetadata,
+            experimental: { preserveInitialOrientation: pluginOptions.experimental?.preserveInitialOrientation }
+          })
           metadata = res.metadata
           if (cacheOptions.enabled) {
             await writeFile(`${cacheOptions.dir}/${id}`, await res.image.toBuffer())

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -95,6 +95,22 @@ export interface VitePluginOptions {
    * Whether to cache transformed images and options for caching.
    */
   cache?: CacheOptions
+
+  /**
+   * These features are not guaranteed to work exactly the same, or even be
+   * present between minor versions.
+   */
+  experimental?: {
+    /**
+     * Sharp's handling of image orientation probably does not match the
+     * expectations of users of imagetools. Enabling this option tries tp preserve
+     * the expectation that an image's transformations are applied on top of the
+     * initial orientation of the image, whether baked into the pixels or
+     * described in the EXIF data.
+     * @default false
+     */
+    preserveInitialOrientation?: boolean
+  }
 }
 
 export interface CacheOptions {


### PR DESCRIPTION
> **NOTE:** This PR is incomplete, but the functionality is all there. It needs documentation and I need to better understand the tests in the Vite package to get those working the way I want. Everything else is ready. I don't have time for docs today, but I will get to them next week at the latest.
>
> I will also rename commit summaries to be in keeping with the format you prefer, but won't do that right away.
>
> Please feel free to start giving feedback about the runtime code and the idea itself. 

Addresses #700 via an experimental setting.

- **Quick Checklist**

🚨 I have not done everything on this list yet. I **will do them**, but I wanted to get some eyes on this draft first.

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable 🚨🚨🚨 This PR needs a changeset. Just haven't done it yet. 

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A new setting is added to both Vite config and as an option to pass into `applyTransforms`.

```ts
{
  experimental: {
    preserveInitialOrientation: boolean
  }
}
```

- **What is the new behavior (if this is a feature change)?**

This opt-in feature will pre-`rotate`/`flip`/`flop` an image based on the EXIF orientation data so that downstream developers can think about their images without first considering whether or not the image appearance is affected by metadata or by actual pixel locations. Two images that look the same might have completely different results when applying `flip`, `flop`, or `rotate`. If you take `removeMetadata` into account, there are even more permutations to consider.

This new setting removes the need to consider all these things. 

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

I have attempted to test initial behavior and ensure that, unless you opt-in, that behavior is exactly the same. So no, there shouldn't be any breaking changes.

- **Other information**: