### PR TITLE
Fix url concatenation for dev mode with origin set in server options

### DIFF
--- a/.changeset/new-otters-turn.md
+++ b/.changeset/new-otters-turn.md
@@ -2,4 +2,4 @@
 'vite-imagetools': patch
 ---
 
-Fixed url concatenation for dev mode with origin set in server options.
+fix: correct URL concatenation in dev mode when origin set in server options

--- a/.changeset/new-otters-turn.md
+++ b/.changeset/new-otters-turn.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+Fixed url concatenation for dev mode with origin set in server options.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,5 +1,4 @@
 import { basename, extname } from 'node:path'
-import { join } from 'node:path/posix'
 import { statSync, mkdirSync, createReadStream } from 'node:fs'
 import { writeFile, readFile, opendir, stat, rm } from 'node:fs/promises'
 import type { Plugin, ResolvedConfig } from 'vite'
@@ -167,7 +166,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             : await readFile(`${cacheOptions.dir}/${id}`)
           ).toString('base64')}`
         } else if (viteConfig.command === 'serve') {
-          metadata.src = join(viteConfig?.server?.origin ?? '', basePath) + id
+          metadata.src = (viteConfig?.server?.origin ?? '') + basePath + id
         } else {
           const fileHandle = this.emitFile({
             name: basename(pathname, extname(pathname)) + `.${metadata.format}`,


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change contains a bug fix for the feature introduced in pull request #690. The server origin option usually contains a  protocol scheme identifier followed by a double slash, e.g. "http://localhost:1234". Nodes POSIX path implementation is not meant to join URLs, which means the double slash is converted to a single slash, resulting in an invalid URL, e.g "http:/localhost:1234". Using url-join instead ensures the result will be a valid URL.

- **Other information**:
Added new dependency: [url-join](https://github.com/jfromaniello/url-join), which seams to be the safest option
