### PR TITLE
fix: crop horizontally when aspect ratio is reduced without width or height

### DIFF
--- a/.changeset/fuzzy-beers-hang.md
+++ b/.changeset/fuzzy-beers-hang.md
@@ -1,0 +1,5 @@
+---
+'imagetools-core': patch
+---
+
+Reducing the aspect ratio without providing width or height works correctly now

--- a/.changeset/fuzzy-beers-hang.md
+++ b/.changeset/fuzzy-beers-hang.md
@@ -2,4 +2,4 @@
 'imagetools-core': patch
 ---
 
-Reducing the aspect ratio without providing width or height works correctly now
+fix: correctly reduce the aspect ratio when no width or height is provided

--- a/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-aspect-transform-w-crop-horizontally-1-snap.png
+++ b/packages/core/src/transforms/__tests__/__image_snapshots__/resize-spec-ts-aspect-transform-w-crop-horizontally-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85597778ed2d8f58445579cc149cd91a06d66913158475bb7ce08edf69dff1ae
+size 290381

--- a/packages/core/src/transforms/__tests__/resize.spec.ts
+++ b/packages/core/src/transforms/__tests__/resize.spec.ts
@@ -283,6 +283,16 @@ describe('aspect', () => {
       expect(await image.toBuffer()).toMatchImageSnapshot()
     })
 
+    test('w/ crop horizontally', async () => {
+      //@ts-expect-error we know this is safe
+      const { image } = await applyTransforms([resize({ aspect: '1:2' }, dirCtx)], img)
+
+      const { width = 0, height = 0 } = await sharp(await image.toBuffer()).metadata()
+      expect(width / height).toEqual(1 / 2)
+
+      expect(await image.toBuffer()).toMatchImageSnapshot()
+    })
+
     test('w/ fit', async () => {
       //@ts-expect-error we know this is safe
       const { image } = await applyTransforms([resize({ aspect: '4:3', fit: 'contain' }, dirCtx)], img)

--- a/packages/core/src/transforms/__tests__/resize.spec.ts
+++ b/packages/core/src/transforms/__tests__/resize.spec.ts
@@ -284,7 +284,7 @@ describe('aspect', () => {
     })
 
     test('w/ crop horizontally', async () => {
-      //@ts-expect-error we know this is safe
+      // @ts-expect-error we know this is safe
       const { image } = await applyTransforms([resize({ aspect: '1:2' }, dirCtx)], img)
 
       const { width = 0, height = 0 } = await sharp(await image.toBuffer()).metadata()

--- a/packages/core/src/transforms/resize.ts
+++ b/packages/core/src/transforms/resize.ts
@@ -74,7 +74,7 @@ export const resize: TransformFactory<ResizeOptions> = (config, context) => {
         finalWidth = originalWidth
       } else {
         finalHeight = originalHeight
-        finalWidth = originalHeight / aspect
+        finalWidth = originalHeight * aspect
       }
     } else if (width && height) {
       // width & height BOTH given, need to look at fit


### PR DESCRIPTION
When the aspect ratio is reduced and no width or height are given the image is now correctly cropped.

Before, if I requested an aspect ratio of 1:2 for an image with dimensions 640x800 it would not change the dimensions of the image. Now the image is correctly cropped to 400x800.

- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable