### PR TITLE
fix: remove legacy import assertion unsupported by Node v22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Unit tests
-on: pull_request
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 
 jobs:
   test:
@@ -16,6 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
       - uses: actions/setup-node@v4
         with:
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,6 +1,10 @@
 import typescript from '@rollup/plugin-typescript'
-import pkg from './package.json' assert { type: 'json' }
-import { builtinModules as builtins } from 'module'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { builtinModules as builtins } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const pkg = JSON.parse(await fs.readFile(path.join(fileURLToPath(import.meta.url), '..', 'package.json')))
 
 const deps = Object.keys(pkg.dependencies || {})
 

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -1,7 +1,10 @@
 import typescript from '@rollup/plugin-typescript'
-import pkg from './package.json' assert { type: 'json' }
-import { builtinModules as builtins } from 'module'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { builtinModules as builtins } from 'node:module'
+import { fileURLToPath } from 'node:url'
 
+const pkg = JSON.parse(await fs.readFile(path.join(fileURLToPath(import.meta.url), '..', 'package.json')))
 const deps = Object.keys(pkg.dependencies || {})
 
 export default {


### PR DESCRIPTION
I wasn’t able to build the project using Node v22 because it used the legacy import assertion syntax. Support for this was removed from Node. To fix this, I’m reading `package.json` as to not rely on JSON module support which may be unavailable on older Node versions (?).

I’m also fixing the Github workflows so that they actually run against different Node versions and we can discover this in the future.

- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~
* [ ] ~~I have added a changeset, if applicable~~