### PR TITLE
fix: avoid hitting the filesystem multiple times when restoring from cache

### DIFF
--- a/.changeset/cute-kids-hear.md
+++ b/.changeset/cute-kids-hear.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: avoid hitting the filesystem multiple times when restoring from cache"


### PR DESCRIPTION
Don't need to do both `sharp` and `readFile`. Also simplifies the code and saves a couple of lines