### PR TITLE
fix: bypass sharp pipeline for cached images

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -66,6 +66,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
   let basePath: string
 
   const generatedImages = new Map<string, { image?: Sharp; metadata: ImageMetadata }>()
+  const cachedBuffers = new Map<string, Buffer>()
 
   return {
     name: 'imagetools',
@@ -168,6 +169,10 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             }
           }
 
+          if (cachedBuffer) {
+            cachedBuffers.set(id, cachedBuffer)
+          }
+
           generatedImages.set(id, { image, metadata })
 
           if (directives.has('inline')) {
@@ -258,6 +263,12 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           }
 
           res.setHeader('Content-Type', `image/${getMetadata(image, 'format')}`)
+
+          const cachedBuffer = cachedBuffers.get(id)
+          if (cachedBuffer) {
+            return res.finish(cachedBuffer)
+          }
+
           return image.clone().pipe(res)
         }
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -169,7 +169,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             }
           }
 
-          if (cachedBuffer) {
+          if (cacheOptions.enabled && cachedBuffer) {
             cachedBuffers.set(id, cachedBuffer)
           }
 


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
  - Didn't have time to write a new test for this at the moment
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the new behavior (if this is a feature change)?**
Responses of cached images will be served faster

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)
Unsure at the moment

- **Other information**:

Cached images are taking as long as uncached images to serve, this is due to images being sent to sharp pipeline even if they were cached, see here for reproduction:
https://codesandbox.io/p/devbox/tn3wgp
