### PR TITLE
fix: use atomic write for cache files to prevent corrupt reads

### DIFF
--- a/.changeset/fix-cache-atomic-write.md
+++ b/.changeset/fix-cache-atomic-write.md
@@ -1,0 +1,18 @@
+---
+"vite-imagetools": patch
+---
+
+fix: use atomic write for cache files to prevent corrupt reads
+
+Node's writeFile opens the target with O_TRUNC, zeroing it before the
+data arrives. A concurrent build process can read that window and pass
+a truncated buffer to sharp, producing a "corrupt header" error that
+points at the image asset rather than the cache.
+
+Fix: write to a uniquely-named temp file (.id.XXXXXX) in the same
+directory, then rename() to the final path. rename() is a single
+atomic syscall. Concurrent readers will only see a complete file.
+
+The temp file follows the same convention as rsync: a dot-prefixed
+name with a random suffix, written in the same destination dir to
+ensure that the filesystem stays the same.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,7 +1,8 @@
 import { basename, extname } from 'node:path'
 import { relative } from 'node:path/posix'
 import { statSync, mkdirSync, createReadStream } from 'node:fs'
-import { readFile, writeFile, opendir, stat, rm } from 'node:fs/promises'
+import { randomBytes } from 'node:crypto'
+import { readFile, writeFile, rename, opendir, stat, rm } from 'node:fs/promises'
 import { normalizePath, type Plugin, type ResolvedConfig } from 'vite'
 import {
   applyTransforms,
@@ -164,7 +165,10 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             metadata = res.metadata
             if (cacheOptions.enabled) {
               cachedBuffer = await image.toBuffer()
-              await writeFile(`${cacheOptions.dir}/${id}`, cachedBuffer)
+              // hidden temp file following rsync's .id.XXXXXX convention; leading dot omitted if id already has one
+              const tmp = `${cacheOptions.dir}/${id.startsWith('.') ? '' : '.'}${id}.${randomBytes(3).toString('hex')}`
+              await writeFile(tmp, cachedBuffer)
+              await rename(tmp, `${cacheOptions.dir}/${id}`)
             }
           }
 


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [ ] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Node's writeFile opens the target with O_TRUNC, zeroing it before the data arrives. A concurrent build process can read that window and pass a truncated buffer to sharp, producing a "corrupt header" error that points at the image asset rather than the cache.

- **What is the new behavior (if this is a feature change)?**

Fix: write to a uniquely-named temp file (.id.XXXXXX) in the same directory, then rename() to the final path. rename() is a single atomic syscall. Concurrent readers will only see a complete file.

The temp file follows the same convention as rsync: a dot-prefixed name with a random suffix, written in the same destination dir to ensure that the filesystem stays the same.

See: https://man7.org/linux/man-pages/man1/rsync.1.html

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this
  PR?)

It does not

- **Other information**:

We discovered this issue because we run several React builds in parallel with vite-imagetools. Builds turned flaky on CI after we moved to vite-imagetools, but never failed when run alone. The error surfaces as a build-time plugin error pointing at the image asset:

```
Error: [imagetools] Could not load src/assets/backgrounds/foo.webp?imagetools (imported by src/themes/bar.ts): Input file contains unsupported image format
```

I didn't use os.tmpdir() because on Linux /tmp is commonly a separate tmpfs mount, and rename() across filesystems fails with EXDEV.

I also have a test case which I haven't included since it needs to mock node's `writeFile`. This makes the test a bit complicated to understand but I am happy to include it if you want to.


