### PR TITLE
chore: add vite package bugs metadata

### DIFF
--- a/.changeset/add-vite-bugs-metadata.md
+++ b/.changeset/add-vite-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"vite-imagetools": patch
+---
+
+Added package metadata for the issue tracker.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/JonasKruckenberg/imagetools.git"
   },
+  "bugs": {
+    "url": "https://github.com/JonasKruckenberg/imagetools/issues"
+  },
   "keywords": [
     "resize-images",
     "responsive-images",


### PR DESCRIPTION
## Summary
- add bugs.url metadata to the vite-imagetools package manifest
- leave runtime code, dependencies, entry points, and package files unchanged

## Validation
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json --cache /private/tmp/codex-npm-cache-imagetools-vite
- git diff --check