### PR TITLE
fix: recompute pixelDensityDescriptor on cache hit

### DIFF
--- a/.changeset/fix-pixel-density-cache.md
+++ b/.changeset/fix-pixel-density-cache.md
@@ -1,0 +1,5 @@
+---
+"vite-imagetools": patch
+---
+
+Fix pixelDensityDescriptor not being set when reading from cache.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -159,6 +159,11 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             // value so emitted filenames don't change between cache misses and cache hits.
             if (typeof imageConfig.format === 'string' && metadata.format !== imageConfig.format)
               metadata.format = imageConfig.format as ImageMetadata['format']
+            // recompute pixelDensityDescriptor from config and the actual resized width.
+            // ImageConfig is typed as string | string[] but resolveConfigs always produces
+            // single string values via cartesian product, so this is always a string.
+            const parsedBasePixels = parseInt(String(imageConfig.basePixels || ''))
+            metadata.pixelDensityDescriptor = parsedBasePixels > 0 ? `${metadata.width / parsedBasePixels}x` : undefined
           } else {
             const { transforms } = generateTransforms(imageConfig, transformFactories, srcURL.searchParams, logger)
             const res = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)


### PR DESCRIPTION
Closes #751.

When reading from cache, applyTransforms is never called so pixelDensityDescriptor was always undefined. This caused srcset to fall back to width descriptors instead of density descriptors.

Compute it inline from imageConfig.basePixels and metadata.width using the same formula as the resize transform, for backwards compatibility with the existing metadata interface.

This is a bit hacky, but I think this is the only way to fix the bug without a braking change.
