### PR TITLE
fix: keep format directive value on cache hits so emitted filenames are stable

### DIFF
--- a/.changeset/spotty-mails-jump.md
+++ b/.changeset/spotty-mails-jump.md
@@ -2,4 +2,4 @@
 'vite-imagetools': patch
 ---
 
-Keep the `format` directive's value when restoring images from the build cache, so emitted asset filenames no longer flip between `.jpg` (cache miss) and `.jpeg` (cache hit). Generalizes the existing avif/heif cache workaround to all formats whose sharp-reported name differs from the directive value.
+fix: keep the `format` directive's value when restoring images from the build cache, so emitted asset filenames no longer flip between `.jpg` and `.jpeg`

--- a/.changeset/spotty-mails-jump.md
+++ b/.changeset/spotty-mails-jump.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+Keep the `format` directive's value when restoring images from the build cache, so emitted asset filenames no longer flip between `.jpg` (cache miss) and `.jpeg` (cache hit). Generalizes the existing avif/heif cache workaround to all formats whose sharp-reported name differs from the directive value.

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -565,6 +565,33 @@ describe('vite-imagetools', () => {
         expect(files).toHaveLength(1)
       })
     })
+
+    describe('cache.jpgFormat', () => {
+      test('keeps the jpg extension on cache hits', async () => {
+        const dir = './node_modules/.cache/imagetools_test_cache_jpg_format'
+        await rm(dir, { recursive: true, force: true })
+        const buildOnce = async () =>
+          (await build({
+            root: join(__dirname, '__fixtures__'),
+            logLevel: 'warn',
+            build: { write: false },
+            plugins: [
+              testEntry(`
+                            import Image from "./pexels-allec-gomes-5195763.png?format=jpg"
+                            window.__IMAGE__ = Image
+                        `),
+              imagetools({ cache: { dir } })
+            ]
+          })) as RollupOutput | RollupOutput[]
+
+        const coldFiles = getFiles(await buildOnce(), '**.jpg') as OutputAsset[]
+        const warmFiles = getFiles(await buildOnce(), '**.jpg') as OutputAsset[]
+
+        expect(coldFiles).toHaveLength(1)
+        expect(warmFiles).toHaveLength(1)
+        expect(warmFiles[0].fileName).toBe(coldFiles[0].fileName)
+      })
+    })
   })
 
   test('relative import', async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -153,10 +153,12 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             image = sharp(cachedBuffer)
             metadata = (await image.metadata()) as ImageMetadata
             // we set the format on the metadata during transformation using the format directive
-            // when restoring from the cache, we use sharp to read it from the image and that results in a different value for avif images
-            // see https://github.com/lovell/sharp/issues/2504 and https://github.com/lovell/sharp/issues/3746
-            if (imageConfig.format === 'avif' && metadata.format === 'heif' && metadata.compression === 'av1')
-              metadata.format = 'avif'
+            // when restoring from the cache, we use sharp to read it from the image and that can result in a
+            // different value: avif images are detected as heif (see https://github.com/lovell/sharp/issues/2504
+            // and https://github.com/lovell/sharp/issues/3746) and jpg is detected as jpeg. Restore the directive
+            // value so emitted filenames don't change between cache misses and cache hits.
+            if (typeof imageConfig.format === 'string' && metadata.format !== imageConfig.format)
+              metadata.format = imageConfig.format as ImageMetadata['format']
           } else {
             const { transforms } = generateTransforms(imageConfig, transformFactories, srcURL.searchParams, logger)
             const res = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)


### PR DESCRIPTION
- **Quick Checklist**

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable

- **What kind of change does this PR introduce?**

Bug fix. Fixes #908.

With the build cache enabled (the default), `?format=jpg` imports emit `.jpg` variants on a cache miss but `.jpeg` variants on a cache hit: the miss path stores the raw directive value in `metadata.format`, while the hit path re-derives metadata via `sharp(cachedBuffer).metadata()`, and sharp reports JPEG as `jpeg`. Since the emitted asset filename extension comes from `metadata.format`, builds sharing a cache directory disagree on asset names. In an SSR setup (client build then server build in the same working directory) the server bundle ends up referencing `.jpeg` URLs the client build never emitted — dangling references that 404 at runtime.

This is the same cache-restore metadata mismatch already special-cased for avif (sharp reads cached avif back as `heif`/`av1`). This PR generalizes that workaround: on a cache hit, restore the directive's format whenever sharp's re-derived value differs. The cache-miss path always keeps the directive value, so this makes the hit path produce exactly the metadata the miss path would — it cannot change behavior for formats where the two already agree, and the existing avif test still passes.

- **What is the new behavior (if this is a feature change)?**

Not a feature change. Emitted filenames are now independent of cache state: `?format=jpg` always emits `.jpg`, on cold and warm caches alike.

- **Does this PR introduce a breaking change?**

No. Projects that (inadvertently) relied on warm-cache builds emitting `.jpeg` for `?format=jpg` will see the extension settle on `.jpg`, which is what a clean build always produced.

- **Other information**:

Note that `metadata.format` also feeds data-URI/`Content-Type` strings (`image/jpg` for `?format=jpg&inline`); that was already the cache-miss behavior before this PR, so this change only removes the hit/miss divergence rather than introducing a new format name anywhere.

The regression test builds twice against a shared cache dir and asserts the `.jpg` asset exists with an identical filename in both bundles; before the fix the warm-cache build emits `.jpeg` and the test fails.
