### PR TITLE
fix(vite): write build cache entries atomically

### DIFF
--- a/.changeset/nervous-cameras-repeat.md
+++ b/.changeset/nervous-cameras-repeat.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+fix: write build cache entries atomically, so an interrupted build can't leave a truncated entry that later builds read back as valid

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -7,9 +7,9 @@ import { type OutputAsset, type OutputChunk, type RollupOutput } from 'rollup'
 import { JSDOM } from 'jsdom'
 import sharp from 'sharp'
 import { afterEach, describe, test, expect, it, vi } from 'vitest'
-import { createBasePath } from '../utils'
+import { createBasePath, writeFileAtomic } from '../utils'
 import { existsSync } from 'node:fs'
-import { rm, utimes, readdir, copyFile } from 'node:fs/promises'
+import { rm, utimes, readdir, copyFile, mkdir, readFile } from 'node:fs/promises'
 
 expect.extend({ toMatchImageSnapshot })
 
@@ -949,6 +949,54 @@ describe('vite-imagetools', () => {
       expect(createBasePath('/base/')).toBe('/base/@imagetools/')
       expect(createBasePath('http://localhost:9000/frontend')).toBe('http://localhost:9000/frontend/@imagetools/')
       expect(createBasePath('http://localhost:9000/frontend/')).toBe('http://localhost:9000/frontend/@imagetools/')
+    })
+
+    describe('writeFileAtomic', () => {
+      const dir = './node_modules/.cache/imagetools_test_write_atomic'
+
+      afterEach(async () => {
+        await rm(dir, { recursive: true, force: true })
+      })
+
+      test('writes the full contents and leaves no temporary files behind', async () => {
+        await mkdir(dir, { recursive: true })
+        const target = `${dir}/entry`
+
+        await writeFileAtomic(target, Buffer.from('complete'))
+
+        expect(await readFile(target, 'utf8')).toBe('complete')
+        expect(await readdir(dir)).toEqual(['entry'])
+      })
+
+      test('a concurrent reader never observes a partially written file', async () => {
+        await mkdir(dir, { recursive: true })
+        const target = `${dir}/entry`
+        const oldContent = Buffer.alloc(4 * 1024 * 1024, 'a')
+        const newContent = Buffer.alloc(4 * 1024 * 1024, 'b')
+        await writeFileAtomic(target, oldContent)
+
+        // read the target repeatedly while a rewrite is in flight. A plain
+        // writeFile() truncates then fills, so readers catch short/mixed content —
+        // exactly the state that later passes the cache's `size > 0` guard and
+        // gets handed to sharp as a valid entry.
+        const sizes = new Set<number>()
+        let reading = true
+        const reader = (async () => {
+          while (reading) {
+            try {
+              sizes.add((await readFile(target)).length)
+            } catch {
+              sizes.add(-1) // target missing entirely
+            }
+          }
+        })()
+
+        await writeFileAtomic(target, newContent)
+        reading = false
+        await reader
+
+        expect([...sizes]).toEqual([oldContent.length])
+      })
     })
   })
 })

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,7 +1,7 @@
 import { basename, extname } from 'node:path'
 import { relative } from 'node:path/posix'
 import { statSync, mkdirSync, createReadStream } from 'node:fs'
-import { readFile, writeFile, opendir, stat, rm } from 'node:fs/promises'
+import { readFile, opendir, stat, rm } from 'node:fs/promises'
 import { normalizePath, type Plugin, type ResolvedConfig } from 'vite'
 import {
   applyTransforms,
@@ -21,7 +21,7 @@ import {
 } from 'imagetools-core'
 import { createFilter, dataToEsm } from '@rollup/pluginutils'
 import sharp, { type Metadata, type Sharp } from 'sharp'
-import { createBasePath, generateImageID, hash } from './utils.js'
+import { createBasePath, generateImageID, hash, writeFileAtomic } from './utils.js'
 import type { VitePluginOptions } from './types.js'
 
 export type {
@@ -166,7 +166,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             metadata = res.metadata
             if (cacheOptions.enabled) {
               cachedBuffer = await image.toBuffer()
-              await writeFile(`${cacheOptions.dir}/${id}`, cachedBuffer)
+              await writeFileAtomic(`${cacheOptions.dir}/${id}`, cachedBuffer)
             }
           }
 

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,5 +1,25 @@
 import { createHash } from 'node:crypto'
+import { writeFile, rename, rm } from 'node:fs/promises'
 import type { ImageConfig } from 'imagetools-core'
+
+let tmpCounter = 0
+
+/**
+ * Writes `data` to `path` by staging it under a unique temporary name in the same
+ * directory and renaming it into place. `rename(2)` is atomic within a filesystem,
+ * so an interrupted build leaves either no file or a complete one — never a
+ * truncated file that a later run would read back as a valid cache entry.
+ */
+export async function writeFileAtomic(path: string, data: Buffer) {
+  const tmpPath = `${path}.${process.pid}-${tmpCounter++}.tmp`
+  try {
+    await writeFile(tmpPath, data)
+    await rename(tmpPath, path)
+  } catch (err) {
+    await rm(tmpPath, { force: true })
+    throw err
+  }
+}
 
 export const createBasePath = (base?: string) => {
   return (base?.replace(/\/$/, '') || '') + '/@imagetools/'


### PR DESCRIPTION
The build cache is written with a plain `writeFile()`:

```js
cachedBuffer = await image.toBuffer()
await writeFile(`${cacheOptions.dir}/${id}`, cachedBuffer)
```

`writeFile()` truncates the target and then fills it, so the entry is observable in a partial state for the duration of the write. Any write that doesn't run to completion leaves a truncated file at the cache path:

- a build interrupted partway (Ctrl-C, CI timeout, OOM kill)
- two builds sharing `node_modules/.cache/imagetools` — `synchronizedTransform` dedupes by id, but that map is per-process, so it doesn't serialise anything across processes (parallel CI jobs, a monorepo building several packages, a build racing a test run)
- the write itself failing under load — asset-heavy projects write thousands of entries concurrently, and an `EMFILE`/`ENOSPC`/transient I/O error partway through leaves the bytes already flushed

The read path only guards on size:

```js
(statSync(`${cacheOptions.dir}/${id}`, { throwIfNoEntry: false })?.size ?? 0) > 0
```

A truncated file passes that guard, so a later build treats it as a valid entry. Two outcomes, and the quiet one is the worse one:

- **Truncated after the header** — `sharp(cachedBuffer).metadata()` succeeds, because metadata only reads the header. The truncated buffer is then handed to `emitFile()`. **A corrupt image is written to the output and the build exits 0.** I hit this on a real project: a 314 KB source PNG shipped as a 64-byte file, no error anywhere.
- **Truncated before the header** — the build fails with `Input buffer contains unsupported image format`.

Both are sticky: the poisoned entry survives until someone manually clears the cache directory, which is why this tends to show up as an intermittent, hard-to-reproduce crash on asset-heavy builds rather than something tied to an obvious trigger.

### Fix

Stage the entry under a unique temp name and `rename()` it into place. `rename(2)` is atomic within a filesystem, so a cache entry is either absent or complete — a partial write is never observable at the target path. The temp name includes the pid, so concurrent builds sharing a cache directory stage to distinct files and the last `rename` simply wins. The temp file is removed if the write fails.

This only changes how the bytes land; cache keys, layout, and the read path are untouched.

### Tests

Two tests in the existing `utils` block:

- entries are written in full and no `.tmp` files are left behind
- a concurrent reader never observes a partially written file

The second is the regression test. Against the previous `writeFile()` implementation it fails with:

```
AssertionError: expected [ +0, 524288, 1572864, 4194304 ] to deeply equal [ 4194304 ]
```

— a reader catching the target at 0 bytes, 512 KB and 1.5 MB mid-write. Those are exactly the states that pass the `size > 0` guard.

### Note on the suite

`packages/vite` has 27 failing tests on `main` at efe000b, unrelated to this change (mostly the `logging` and rollup-error assertions). This PR takes it from 13 passed / 27 failed to 15 passed / 27 failed.

### Follow-up worth considering

The read path could also be hardened — wrapping the cache-hit decode and falling through to a re-transform on failure would let already-corrupted caches self-heal instead of needing a manual `rm -rf`. I left it out to keep this focused on the root cause; happy to add it here if you'd prefer.
