### PR TITLE
perf(vite): hash source bytes instead of a decoded buffer for cache keys

### DIFF
--- a/.changeset/olive-pots-shave.md
+++ b/.changeset/olive-pots-shave.md
@@ -1,0 +1,5 @@
+---
+'vite-imagetools': patch
+---
+
+perf: hash the source file bytes instead of a decoded buffer when building cache keys, so the plugin no longer pays a full sharp decode for every image on every build

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -138,7 +138,12 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           error: (msg) => this.error(msg)
         }
 
-        const imageHash = hash([await img.toBuffer()])
+        // Hash the source bytes rather than a decoded buffer. This runs for every
+        // image before the cache is consulted, so decoding here is paid on every
+        // build even when every entry is a cache hit. The file contents identify
+        // the image just as uniquely, and more conservatively: two encodings of
+        // the same pixels no longer share a cache key.
+        const imageHash = hash([await readFile(pathname)])
 
         const executeTransform = async (id: string, imageConfig: ImageConfig) => {
           let image: Sharp | undefined


### PR DESCRIPTION
`imageHash` is computed for every image *before* the cache is consulted:

```js
const imageHash = hash([await img.toBuffer()])

const executeTransform = async (id, imageConfig) => {
  if (cacheOptions.enabled && (statSync(`${cacheOptions.dir}/${id}`, …)?.size ?? 0) > 0) {
    // cache hit
```

`img.toBuffer()` runs a full sharp decode and re-encode of the source image. Because the hash feeds `generateImageID()`, which produces the cache key, this happens before any cache lookup can — so it's paid on **every build for every image, even at a 100% cache hit rate**. The cache avoids the transforms but never this.

Hashing the source file bytes gives the same guarantee for free. It's also strictly more conservative: two different encodings of the same pixels used to hash equal and share a cache entry, and now they don't.

### Impact

Measured on a project with ~4,900 cached images, warm cache, client build:

| | before | after |
|---|---|---|
| imagetools share of plugin time | 61% | **22%** |
| client build | 52.5s | **49.2s** |

Output is unchanged: all 11,863 emitted images decode cleanly and the total bundle is within 0.2 kB (hash-length noise in filenames).

### Compatibility

Cache keys change, so the first build after upgrading repopulates the cache. No output, API, or option changes.

One thing to flag: `cache.dir > is consistent` pins a literal hash (`025427654209b031953f8db8178d897aafa026ce`) that this PR necessarily changes. I haven't updated it, because that test — along with the other cache tests — is already failing on `main` at efe000b for an unrelated reason: the cache directory comes back empty (`expected [] to have a length of 1`). Same 27 failed / 13 passed before and after this change. Once that suite is fixed the pinned value will need regenerating, and I'm happy to do it here if you'd rather.
