### PR TITLE
Fix a batch of caching problems

### DIFF
--- a/.changeset/lazy-rivers-sing.md
+++ b/.changeset/lazy-rivers-sing.md
@@ -1,0 +1,7 @@
+---
+"vite-imagetools": patch
+---
+
+Report the encoded image's metadata on a cache miss
+
+A metadata import now reports the same raw sharp metadata whether the image came from the cache or a fresh process: the cache-miss path reads the encoded output's metadata instead of the source image's, so fields like `isProgressive`, `hasAlpha`, `pages` or `density` no longer differ between the two.

--- a/.changeset/quick-dots-repeat.md
+++ b/.changeset/quick-dots-repeat.md
@@ -1,0 +1,8 @@
+---
+"vite-imagetools": major
+"imagetools-core": major
+---
+
+Drop applied-transform directives from the `as=metadata` output
+
+The `as=metadata` export no longer includes the applied-transform directive values (`flip`, `quality`, `rotate`, ...), only the final output `width`, `height`, `format`, the image's sharp metadata and the `src`. The applied transforms cannot be reconstructed from a cached file, so previously a metadata import that hit a cache entry could fail with a `MISSING_EXPORT` error or silently omit those fields; dropping them makes the export deterministic across cache hits and misses.

--- a/.changeset/small-pandas-float.md
+++ b/.changeset/small-pandas-float.md
@@ -1,0 +1,13 @@
+---
+"vite-imagetools": major
+"imagetools-core": major
+---
+
+Make `ImageConfig` a record of single-string directives, excluding output-format parameters
+
+`ImageConfig` values are now always single strings. The output-format parameters that previously kept their array values on `config` no longer appear in the configs at all:
+
+- `resolveConfigs` now returns an array of single-value directive records (`ImageConfig[]`), excluding the output-format parameters and the `as` output format selector that previously appeared as array values on `config`.
+- Transform factories and options now receive only the single-value directives, so `metadata[key]` is `string | undefined` rather than `string | string[] | undefined`.
+- Output format parameters and the `as` selector no longer affect the generated cache id, since they only influence how the already-processed image is serialized. URLs that differ only in these parameters share a single cache entry.
+- Every key in `outputFormats` is excluded from the configs, including custom output formats. A custom output format whose name collides with a transform directive name suppresses that directive (e.g. a custom output format named `blur` makes `?blur=5` stop applying the blur transform); name custom output formats to avoid directive names, since any key matching an output format is dropped from the configs.

--- a/packages/core/src/__tests__/generate-configs.spec.ts
+++ b/packages/core/src/__tests__/generate-configs.spec.ts
@@ -2,7 +2,7 @@ import { resolveConfigs } from '../lib/resolve-configs'
 import { builtinOutputFormats } from '../'
 import { describe, test, it, expect } from 'vitest'
 
-describe('generateConfigs', () => {
+describe('resolveConfigs', () => {
   it('accepts and array of entries', () => {
     const e: [string, string[]][] = [
       ['foo', ['bar']],
@@ -13,7 +13,7 @@ describe('generateConfigs', () => {
     expect(() => resolveConfigs(e, builtinOutputFormats)).not.toThrow()
   })
 
-  it('returns an array of objects', () => {
+  it('returns an array of configs', () => {
     const e: [string, string[]][] = [
       ['foo', ['bar']],
       ['hello', ['world']],
@@ -26,7 +26,7 @@ describe('generateConfigs', () => {
     expect(res[0]).toBeInstanceOf(Object)
   })
 
-  it('returns a single object if only single arguments are used', () => {
+  it('returns a single config if only single arguments are used', () => {
     const e: [string, string[]][] = [
       ['foo', ['bar']],
       ['hello', ['world']],
@@ -35,11 +35,10 @@ describe('generateConfigs', () => {
 
     const res = resolveConfigs(e, builtinOutputFormats)
 
-    expect(res).toBeInstanceOf(Array)
     expect(res).toHaveLength(1)
   })
 
-  it('returns a single object if only single arguments are used', () => {
+  it('returns a config per combination of argument values', () => {
     const e: [string, string[]][] = [
       ['foo', ['bar']],
       ['hello', ['world']],
@@ -48,7 +47,6 @@ describe('generateConfigs', () => {
 
     const res = resolveConfigs(e, builtinOutputFormats)
 
-    expect(res).toBeInstanceOf(Array)
     expect(res).toHaveLength(2)
   })
 
@@ -83,7 +81,7 @@ describe('generateConfigs', () => {
     }
   })
 
-  test('returned objects all have string values', () => {
+  test('config objects all have string values', () => {
     const e: [string, string[]][] = [
       ['width', ['300', '400']],
       ['height', ['100', '700']]
@@ -91,9 +89,9 @@ describe('generateConfigs', () => {
 
     const res = resolveConfigs(e, builtinOutputFormats)
 
-    for (const options of res) {
-      for (const key in options) {
-        expect(typeof options[key]).toBe('string')
+    for (const config of res) {
+      for (const key in config) {
+        expect(typeof config[key]).toBe('string')
       }
     }
   })
@@ -141,5 +139,41 @@ describe('generateConfigs', () => {
     const res = resolveConfigs(e, builtinOutputFormats)
 
     expect(res).toHaveLength(1)
+    expect(res[0]).toEqual({})
+  })
+
+  test('output format parameters are excluded from the image configs', () => {
+    const e: [string, string[]][] = [
+      ['width', ['300', '400']],
+      ['metadata', ['width', 'height']]
+    ]
+
+    const res = resolveConfigs(e, builtinOutputFormats)
+
+    expect(res[0]).toEqual({ width: '300' })
+    expect(res).toHaveLength(2)
+  })
+
+  test('the as output format selector is excluded from the image configs', () => {
+    const e: [string, string[]][] = [
+      ['width', ['300']],
+      ['as', ['metadata']]
+    ]
+
+    const res = resolveConfigs(e, builtinOutputFormats)
+
+    expect(res).toEqual([{ width: '300' }])
+  })
+
+  test('a custom output format suppresses a directive of the same name', () => {
+    const e: [string, string[]][] = [
+      ['width', ['300']],
+      ['blur', ['5']]
+    ]
+    const outputFormats = { ...builtinOutputFormats, blur: () => () => '' }
+
+    const res = resolveConfigs(e, outputFormats)
+
+    expect(res).toEqual([{ width: '300' }])
   })
 })

--- a/packages/core/src/__tests__/output-formats.test.ts
+++ b/packages/core/src/__tests__/output-formats.test.ts
@@ -88,11 +88,6 @@ describe('metadata format', () => {
       height: 150,
       format: 'webp'
     })
-    expect(output).not.toHaveProperty('flip')
-    expect(output).not.toHaveProperty('quality')
-    expect(output).not.toHaveProperty('rotate')
-    expect(output).not.toHaveProperty('tint')
-    expect(output).not.toHaveProperty('fit')
   })
 
   test('whitelist', () => {

--- a/packages/core/src/__tests__/output-formats.test.ts
+++ b/packages/core/src/__tests__/output-formats.test.ts
@@ -7,7 +7,7 @@ function meta(
   width: number,
   height = width,
   format?: string,
-  config: Record<string, string | string[]> = {},
+  config: Record<string, string> = {},
   raw: Partial<Metadata> = {},
   transforms: Partial<AppliedTransforms> = {}
 ): ProcessedImage {

--- a/packages/core/src/__tests__/output-formats.test.ts
+++ b/packages/core/src/__tests__/output-formats.test.ts
@@ -77,7 +77,7 @@ describe('metadata format', () => {
     ])
   })
 
-  test('includes the values threaded through the transforms', () => {
+  test('does not include the values threaded through the transforms', () => {
     const output = metadataFormat()([
       meta('/foo.jpg', 300, 150, 'webp', {}, {}, { flip: true, quality: 80, rotate: 90, tint: '#ff0000', fit: 'cover' })
     ])
@@ -86,13 +86,13 @@ describe('metadata format', () => {
       src: '/foo.jpg',
       width: 300,
       height: 150,
-      format: 'webp',
-      flip: true,
-      quality: 80,
-      rotate: 90,
-      tint: '#ff0000',
-      fit: 'cover'
+      format: 'webp'
     })
+    expect(output).not.toHaveProperty('flip')
+    expect(output).not.toHaveProperty('quality')
+    expect(output).not.toHaveProperty('rotate')
+    expect(output).not.toHaveProperty('tint')
+    expect(output).not.toHaveProperty('fit')
   })
 
   test('whitelist', () => {

--- a/packages/core/src/__tests__/parse-url.spec.ts
+++ b/packages/core/src/__tests__/parse-url.spec.ts
@@ -46,4 +46,13 @@ describe('extractEntries', () => {
 
     expect(asObject).toHaveProperty('w', ['300', '400', '500'])
   })
+
+  it('keeps values containing ":" whole', () => {
+    const src = new URL('/test.jpg?aspect=16:9;4:3', 'file:///')
+
+    const entries = extractEntries(src.searchParams)
+    const asObject = Object.fromEntries(entries)
+
+    expect(asObject).toHaveProperty('aspect', ['16:9;4:3'])
+  })
 })

--- a/packages/core/src/lib/resolve-configs.ts
+++ b/packages/core/src/lib/resolve-configs.ts
@@ -8,28 +8,26 @@ const cartesian = <T>(sets: T[][]) =>
 
 /**
  * Builds every combination the given URL entries can be combined into, as an
- * array of configs that can be passed to the transforms. Output format
- * parameters (e.g. `as=`) are appended to every combination instead of
- * contributing to the product.
+ * array of image configs that can be passed to the transforms. Output format
+ * parameters and the `as` output format selector do not contribute to the
+ * product. Note that every key in `outputFormats` is excluded, including custom
+ * output formats, so a custom output format whose name collides with a
+ * transform directive name will suppress that directive.
  * @param entries The URL parameter entries
- * @returns An array of directive configs
+ * @returns The image configs
  */
 export function resolveConfigs(
   entries: Array<[string, string[]]>,
   outputFormats: Record<string, OutputFormat>
 ): ImageConfig[] {
-  // create a new array of entries for each argument
+  // create a new array of entries for each argument, excluding output format
+  // parameters and the `as` output format selector
   const singleArgumentEntries = entries
-    .filter(([k]) => !(k in outputFormats))
+    .filter(([k]) => !(k in outputFormats) && k !== 'as')
     .map(([key, values]) => values.map<[string, string]>((v) => [key, v]))
 
   // do a cartesian product on all entries to get all combinations we need to produce
   const combinations = cartesian(singleArgumentEntries)
 
-  const metadataAddons = entries.filter(([k]) => k in outputFormats)
-
-  // and return as an array of objects
-  const out: ImageConfig[] = combinations.map((options) => Object.fromEntries([...options, ...metadataAddons]))
-
-  return out.length ? out : [Object.fromEntries(metadataAddons)]
+  return combinations.map((options) => Object.fromEntries(options))
 }

--- a/packages/core/src/output-formats.ts
+++ b/packages/core/src/output-formats.ts
@@ -66,8 +66,8 @@ function pick<T extends object>(source: T, keys: string[]): Partial<T> {
  * Parses the `basePixels` directive into a positive number, or `undefined` if it is not set or invalid.
  * A `basePixels` value of `0` or less disables pixel density descriptors.
  */
-function parseBasePixels(value: string | string[] | undefined): number | undefined {
-  if (typeof value !== 'string') return undefined
+function parseBasePixels(value: string | undefined): number | undefined {
+  if (typeof value !== 'string' || !value) return undefined
   const basePixels = Number(value)
   return Number.isFinite(basePixels) && basePixels > 0 ? basePixels : undefined
 }

--- a/packages/core/src/output-formats.ts
+++ b/packages/core/src/output-formats.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from 'sharp'
-import type { AppliedTransforms, Img, OutputFormat, Picture, ProcessedImage } from './types.js'
+import type { Img, OutputFormat, Picture, ProcessedImage } from './types.js'
 
 /**
  * Emits the URL of the image, or an array of URLs when multiple configs are resolved.
@@ -18,20 +18,19 @@ export const srcsetFormat: OutputFormat = () => metadatasToSourceset
 
 /**
  * The flat object emitted by the `as=metadata` output format: the raw sharp
- * metadata of the source image combined with the values threaded through the
- * transforms, with `width`, `height` and `format` reflecting the final output,
- * plus the image URL.
+ * metadata of the image combined with the final output `width`, `height` and
+ * `format`, plus the image URL. The applied-transform directives are not
+ * included, since they cannot be reconstructed from a cached file, keeping the
+ * output identical between cache hits and misses.
  */
-type FlatMetadata = Omit<Metadata, 'format'> &
-  Omit<AppliedTransforms, 'format'> & {
-    format: string
-    src: string
-  }
+type FlatMetadata = Omit<Metadata, 'format'> & {
+  format: string
+  src: string
+}
 
 function flatten(metadata: ProcessedImage): FlatMetadata {
   return {
     ...metadata.sharpMetadata,
-    ...metadata.transforms,
     width: metadata.info.width,
     height: metadata.info.height,
     format: metadata.transforms.format ?? metadata.sharpMetadata.format,

--- a/packages/core/src/transforms/background.ts
+++ b/packages/core/src/transforms/background.ts
@@ -5,7 +5,7 @@ export interface BackgroundOptions {
 }
 
 export const getBackground: TransformOption<BackgroundOptions, string> = ({ background }, state) => {
-  if (typeof background !== 'string' || !background.length) return
+  if (typeof background !== 'string' || !background) return
 
   state.transforms.backgroundDirective = background
   return background

--- a/packages/core/src/transforms/tint.ts
+++ b/packages/core/src/transforms/tint.ts
@@ -5,7 +5,7 @@ export interface TintOptions {
 }
 
 export const tint: TransformFactory<TintOptions> = ({ tint }) => {
-  if (typeof tint !== 'string' || !tint.length) return
+  if (typeof tint !== 'string' || !tint) return
 
   return function tintTransform(state, image) {
     state.transforms.tint = '#' + tint

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,7 +64,7 @@ export interface ProcessedImage extends ImageMetadata {
   src: string
   /** The sharp instance of the processed image. */
   image: Sharp
-  /** The config used to generate this image. */
+  /** The directives used to generate this image. */
   config: ImageConfig
   /**
    * The sharp metadata of the image. On a cache miss this is read from the source
@@ -74,7 +74,12 @@ export interface ProcessedImage extends ImageMetadata {
   sharpMetadata: Metadata
 }
 
-export type ImageConfig = Record<string, string | string[]>
+/**
+ * The directives for a single image. Each value is resolved to a single string
+ * by the cartesian product computed in `resolveConfigs`, so consumers never have
+ * to handle array values.
+ */
+export type ImageConfig = Record<string, string>
 
 export interface Logger {
   info: (msg: string) => void

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,9 +67,9 @@ export interface ProcessedImage extends ImageMetadata {
   /** The directives used to generate this image. */
   config: ImageConfig
   /**
-   * The sharp metadata of the image. On a cache miss this is read from the source
-   * before any transformations; when restored from a cache it is read from the
-   * processed output instead.
+   * The sharp metadata of the processed image, read from the encoded output,
+   * so it is identical whether the image came from a cache hit or a fresh
+   * process.
    */
   sharpMetadata: Metadata
 }

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -7,7 +7,7 @@ import { type OutputAsset, type OutputChunk, type RollupOutput } from 'rollup'
 import { JSDOM } from 'jsdom'
 import sharp from 'sharp'
 import { afterEach, describe, test, expect, it, vi } from 'vitest'
-import { createBasePath, writeFileAtomic } from '../utils'
+import { createBasePath, writeFileAtomic, generateImageID, hash } from '../utils'
 import { existsSync } from 'node:fs'
 import { rm, utimes, readdir, copyFile, mkdir, readFile } from 'node:fs/promises'
 import { createServer as createHttpServer } from 'node:http'
@@ -527,10 +527,67 @@ describe('vite-imagetools', () => {
       })
 
       test('is consistent', async () => {
-        const image = (await readdir(dir))[0]
+        const dir = './node_modules/.cache/imagetools_test_cache_dir'
+        await rm(dir, { recursive: true, force: true })
+        const root = join(__dirname, '__fixtures__')
+        await build({
+          root,
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                            import Image from "./pexels-allec-gomes-5195763.png?w=300"
+                            export default Image
+                        `),
+            imagetools({ cache: { dir } })
+          ]
+        })
 
-        expect(image).toBe('2140167b8e6e7157f578cd3ab633ef5f189dbe66')
+        const imageHash = hash([await readFile(join(__dirname, '__fixtures__', 'pexels-allec-gomes-5195763.png'))])
+        expect(await readdir(dir)).toEqual([generateImageID({ w: '300' }, imageHash)])
       })
+    })
+
+    test('output format parameters do not create separate cache entries', async () => {
+      const dir = './node_modules/.cache/imagetools_test_cache_output_format'
+      await rm(dir, { recursive: true, force: true })
+
+      const buildImport = async (directives: string) => {
+        await build({
+          root: join(__dirname, '__fixtures__'),
+          logLevel: 'warn',
+          build: { write: false },
+          plugins: [
+            testEntry(`
+                import Image from "./pexels-allec-gomes-5195763.png?w=300&${directives}"
+                export default Image
+            `),
+            imagetools({ cache: { dir } })
+          ]
+        })
+      }
+
+      const imageHash = hash([await readFile(join(__dirname, '__fixtures__', 'pexels-allec-gomes-5195763.png'))])
+      const expectedId = generateImageID({ w: '300' }, imageHash)
+
+      for (const directives of [
+        'metadata=width',
+        'metadata=width;height',
+        'as=metadata',
+        'as=url',
+        'as=srcset',
+        'as=picture'
+      ]) {
+        await buildImport(directives)
+      }
+
+      // the directives are the same, so every import shares one cache entry even
+      // though their output format parameters differ
+      expect(await readdir(dir)).toEqual([expectedId])
+
+      // a change in an actual directive produces a separate entry
+      await buildImport('w=200&metadata=width')
+      expect(await readdir(dir)).toEqual([expectedId, generateImageID({ w: '200' }, imageHash)])
     })
 
     describe('cache.avifFormat', () => {

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -921,6 +921,39 @@ describe('vite-imagetools', () => {
     expect(warm).not.toHaveProperty('flip')
   })
 
+  test('metadata import is identical on a cache hit and a cache miss', async () => {
+    const dir = './node_modules/.cache/imagetools_test_metadata_parity'
+    await rm(dir, { recursive: true, force: true })
+
+    const buildMetadata = async () => {
+      const bundle = (await build({
+        root: join(__dirname, '__fixtures__'),
+        logLevel: 'warn',
+        build: { write: false },
+        plugins: [
+          testEntry(`
+                    import Image from "./pexels-allec-gomes-5195763.png?w=300&flip=true&format=webp&as=metadata"
+                    window.__IMAGE__ = Image
+                `),
+          imagetools({ cache: { dir } })
+        ]
+      })) as RollupOutput | RollupOutput[]
+
+      const files = getFiles(bundle, '**.js') as OutputChunk[]
+      const { window } = new JSDOM(``, { runScripts: 'outside-only' })
+      window.eval(files[0].code)
+      return window.__IMAGE__
+    }
+
+    const cold = await buildMetadata() // cache miss
+    const warm = await buildMetadata() // cache hit
+
+    const { src: coldSrc, ...coldRest } = cold
+    const { src: warmSrc, ...warmRest } = warm
+    expect(coldSrc).toBe(warmSrc)
+    expect(warmRest).toEqual(coldRest)
+  })
+
   test('autoOrient is applied automatically', async () => {
     const bundle = (await build({
       root: join(__dirname, '__fixtures__'),

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -865,7 +865,7 @@ describe('vite-imagetools', () => {
     expect(window.__IMAGE__).not.toHaveProperty('config')
   })
 
-  test('metadata import includes applied transform directives', async () => {
+  test('metadata import does not include applied transform directives', async () => {
     const bundle = (await build({
       root: join(__dirname, '__fixtures__'),
       logLevel: 'warn',
@@ -885,8 +885,40 @@ describe('vite-imagetools', () => {
 
     expect(window.__IMAGE__.width).toBe(300)
     expect(window.__IMAGE__.format).toBe('webp')
-    expect(window.__IMAGE__.flip).toBe(true)
+    expect(window.__IMAGE__).not.toHaveProperty('flip')
     expect(window.__IMAGE__).toHaveProperty('height')
+  })
+
+  test('metadata import omits transform directives on a cache hit', async () => {
+    const dir = './node_modules/.cache/imagetools_test_metadata_cache_hit'
+    await rm(dir, { recursive: true, force: true })
+
+    const buildMetadata = async () => {
+      const bundle = (await build({
+        root: join(__dirname, '__fixtures__'),
+        logLevel: 'warn',
+        build: { write: false },
+        plugins: [
+          testEntry(`
+                    import Image from "./pexels-allec-gomes-5195763.png?w=300&flip=true&format=webp&as=metadata"
+                    window.__IMAGE__ = Image
+                `),
+          imagetools({ cache: { dir } })
+        ]
+      })) as RollupOutput | RollupOutput[]
+
+      const files = getFiles(bundle, '**.js') as OutputChunk[]
+      const { window } = new JSDOM(``, { runScripts: 'outside-only' })
+      window.eval(files[0].code)
+      return window.__IMAGE__
+    }
+
+    await buildMetadata() // cold: writes the cache entry
+    const warm = await buildMetadata() // warm: served from the cache
+
+    expect(warm.width).toBe(300)
+    expect(warm.format).toBe('webp')
+    expect(warm).not.toHaveProperty('flip')
   })
 
   test('autoOrient is applied automatically', async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -171,7 +171,9 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             // different value: avif images are detected as heif (see https://github.com/lovell/sharp/issues/2504
             // and https://github.com/lovell/sharp/issues/3746) and jpg is detected as jpeg. Restore the directive
             // value so emitted filenames don't change between cache misses and cache hits.
-            if (typeof imageConfig.format === 'string' && metadata.transforms.format !== imageConfig.format)
+            // `ImageConfig` values are always strings, so a missing `format` is the only
+            // `undefined` case; custom `resolveConfigs` overrides must return string values.
+            if (imageConfig.format !== undefined && metadata.transforms.format !== imageConfig.format)
               metadata.transforms.format = imageConfig.format
           } else {
             const { transforms } = generateTransforms(imageConfig, transformFactories, srcURL.searchParams, logger)

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -180,7 +180,6 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             const res = await applyTransforms(transforms, img.clone(), pluginOptions.removeMetadata)
             image = res.image
             metadata = res.metadata
-            raw = res.raw
             // Transforms report their target dimensions on the metadata, but the encoded image can differ
             // (e.g. `rotate` swaps width and height). Reconcile against the actual output so the metadata
             // and the pixel density descriptors derived from it match the dimensions the cache-hit path
@@ -189,6 +188,9 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
             cachedBuffer = data
             metadata.info.width = info.width
             metadata.info.height = info.height
+            // Read the metadata from the encoded output so a cache miss reports the
+            // same `sharpMetadata` as the cache-hit path reads back from the file.
+            raw = await sharp(cachedBuffer).metadata()
             if (cacheOptions.enabled) {
               await writeFileAtomic(`${cacheOptions.dir}/${id}`, cachedBuffer)
             }


### PR DESCRIPTION

I wanted to make this PR before 11.0.0 was out and slip all these breaking changes in there, but im late so whatever

## Summary

The image cache is the plugin's source of truth for both the bytes it serves and the metadata a `metadata` import reports, but it was never keyed or populated consistently. This PR is a sweep of cache fixes: the cache id mixed in output-format params that cannot change the bytes, `as=metadata` imports spun up their own redundant cache entries, and the metadata they returned differed depending on whether the image was served from the cache or processed fresh.

## 1. Cache ids are keyed only by image directives

- `ImageConfig` is now `Record<string, string>` (single-string directives only, never arrays); `resolveConfigs` still returns the same `ImageConfig[]` shape, so existing custom `resolveConfigs` overrides keep working unchanged. Because the config now holds only directives that affect the bytes, the cache id derived from it finally matches the data.
- Transform options now see `string | undefined` instead of `string | string[] | undefined`. The `string[]` branches are gone from `background`, `tint`, `parseBasePixels`, and the output-format restore path; the runtime guards stay, so a custom resolver returning a non-string is skipped rather than mis-applied.

## 2. Serialization params no longer split the cache

- Output-format params and the `as` selector are excluded from the configs and from the cartesian product. Since the cache id hashes only the directives, URLs that differ only in `as`/`metadata=` collapse into one cache entry instead of duplicating identical sharp work and disk. `generateImageID` itself is unchanged; the change comes entirely from the configs no longer containing those params.

## 3. `as=metadata` is deterministic across cache hits and misses

- **Applied-transform directives are no longer exported.** They were just the inputs, an echo of what the user typed into the import URL, so exporting them back wasn't very meaningful anyways. And they just didn't work with cache at all. It may be possible to either cache them or reconstruct them but I don't see value in that.
- **The cache-miss path reads the encoded output's metadata.** instead of the source image's, so a miss reports exactly what the hit path reads back from the file: `isProgressive`, `hasAlpha`, `pages`, `density`, etc. never differ.

## Smaller details

- A custom output format whose name collides with a directive name (e.g. a format named `blur`) suppresses that directive, since every key in `outputFormats` is excluded from the configs. This is documented in the `resolveConfigs` JSDoc and the changeset; name custom formats to avoid directive names.

## Breaking changes

- `ImageConfig` values are single strings, never arrays.
- Transform options are `string | undefined`, not `string | string[] | undefined`.
- `as=metadata` imports no longer include the applied-transform directive fields.
- Cache ids change for imports carrying `as`/output-format params (they collapse to the directive-only id).

## Testing

- core (295): `resolveConfigs` product/exclusion cases, `as` exclusion, custom output-format name suppressing a directive, string-only values, metadata output without transform directives, `:` guard.
- vite (50): shared cache entry across `metadata=width`, `metadata=width;height`, `as=metadata`, `as=url`, `as=srcset`, `as=picture`; custom `resolveConfigs` override; metadata omitting transform directives on both a cold and a warm cache; metadata identical across a cache hit and miss.
- `pnpm lint` and `tsc --noEmit` are clean.


## Quick Checklist

* [x] I have read [the contributing guidelines](../CONTRIBUTING.md)
* [x] I have written new tests, as applicable (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)
* [x] I have added a changeset, if applicable