### PR TITLE
fix(vite): respond to an unknown image id instead of throwing

### DIFF
--- a/.changeset/lucky-donkeys-repeat.md
+++ b/.changeset/lucky-donkeys-repeat.md
@@ -2,15 +2,4 @@
 'vite-imagetools': patch
 ---
 
-Respond to an unknown image id instead of throwing
-
-The dev-server middleware threw when an id was missing from the generated-images
-map. The response status was already 404, but throwing additionally made Vite
-classify it as an internal server error, which raises the dev error overlay over
-the whole page — and in a browser test harness that overlay sits above the page
-and silently swallows clicks aimed at it. The thrown stack was also misleading,
-unwinding through middleware registered earlier so its top frames were unrelated
-ones such as `hostValidation` and `cors` rather than the plugin.
-
-The miss is now answered with a 404 whose body names the id, and the diagnostic
-is logged rather than thrown.
+fix: log an unknown image ID instead of throwing

--- a/.changeset/lucky-donkeys-repeat.md
+++ b/.changeset/lucky-donkeys-repeat.md
@@ -1,0 +1,16 @@
+---
+'vite-imagetools': patch
+---
+
+Respond to an unknown image id instead of throwing
+
+The dev-server middleware threw when an id was missing from the generated-images
+map. The response status was already 404, but throwing additionally made Vite
+classify it as an internal server error, which raises the dev error overlay over
+the whole page — and in a browser test harness that overlay sits above the page
+and silently swallows clicks aimed at it. The thrown stack was also misleading,
+unwinding through middleware registered earlier so its top frames were unrelated
+ones such as `hostValidation` and `cors` rather than the plugin.
+
+The miss is now answered with a 404 whose body names the id, and the diagnostic
+is logged rather than thrown.

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -1181,9 +1181,14 @@ describe('vite-imagetools', () => {
   })
 
   test('dev server serves transformed images through the middleware', async () => {
+    const logger = createLogger('silent')
+    const loggedErrors: string[] = []
+    logger.error = (msg) => loggedErrors.push(msg)
+
     const vite = await createServer({
       root: join(__dirname, '__fixtures__'),
       logLevel: 'silent',
+      customLogger: logger,
       server: { middlewareMode: true },
       plugins: [imagetools({ cache: { enabled: false } })]
     })
@@ -1202,8 +1207,15 @@ describe('vite-imagetools', () => {
     expect(res.headers.get('content-type')).toBe('image/webp')
     expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0)
 
+    // A miss is answered, not thrown. The status was 404 either way, so it is the
+    // rest of this that pins the behaviour: the body names the id instead of being
+    // a generic HTML error page, and Vite is never told this was an internal
+    // server error — which is what raises the dev overlay over the whole page.
     const missing = await fetch(`http://localhost:${port}/@imagetools/does-not-exist`)
     expect(missing.status).toBe(404)
+    expect(await missing.text()).toContain('does-not-exist')
+    expect(loggedErrors.join('\n')).toContain('cannot find image with id "does-not-exist"')
+    expect(loggedErrors.join('\n')).not.toContain('Internal server error')
 
     await new Promise<void>((resolve) => http.close(resolve))
     await vite.close()

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -1210,7 +1210,7 @@ describe('vite-imagetools', () => {
     const missing = await fetch(`http://localhost:${port}/@imagetools/does-not-exist`)
     expect(missing.status).toBe(404)
     expect(await missing.text()).toContain('does-not-exist')
-    expect(loggedErrors.join('\n')).toContain('cannot find image with id "does-not-exist"')
+    expect(loggedErrors.join('\n')).toContain('vite-imagetools cannot find image with id "does-not-exist"')
     expect(loggedErrors.join('\n')).not.toContain('Internal server error')
 
     await new Promise<void>((resolve) => http.close(resolve))

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -1207,10 +1207,6 @@ describe('vite-imagetools', () => {
     expect(res.headers.get('content-type')).toBe('image/webp')
     expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0)
 
-    // A miss is answered, not thrown. The status was 404 either way, so it is the
-    // rest of this that pins the behaviour: the body names the id instead of being
-    // a generic HTML error page, and Vite is never told this was an internal
-    // server error — which is what raises the dev overlay over the whole page.
     const missing = await fetch(`http://localhost:${port}/@imagetools/does-not-exist`)
     expect(missing.status).toBe(404)
     expect(await missing.text()).toContain('does-not-exist')

--- a/packages/vite/src/__tests__/main.test.ts
+++ b/packages/vite/src/__tests__/main.test.ts
@@ -1210,7 +1210,7 @@ describe('vite-imagetools', () => {
     const missing = await fetch(`http://localhost:${port}/@imagetools/does-not-exist`)
     expect(missing.status).toBe(404)
     expect(await missing.text()).toContain('does-not-exist')
-    expect(loggedErrors.join('\n')).toContain('vite-imagetools cannot find image with id "does-not-exist"')
+    expect(loggedErrors.join('\n')).toContain('vite-imagetools cannot find image with requested id "does-not-exist"')
     expect(loggedErrors.join('\n')).not.toContain('Internal server error')
 
     await new Promise<void>((resolve) => http.close(resolve))

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -286,7 +286,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           // which in dev raises the error overlay over the whole page. That is a
           // large consequence for one image failing to resolve.
           if (!processedImage) {
-            server.config.logger.warn(`vite-imagetools cannot find image with requested id "${id}"`)
+            server.config.logger.error(`vite-imagetools cannot find image with requested id "${id}"`)
 
             res.statusCode = 404
             res.setHeader('Content-Type', 'text/plain')

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -286,9 +286,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           // which in dev raises the error overlay over the whole page. That is a
           // large consequence for one image failing to resolve.
           if (!processedImage) {
-            server.config.logger.warn(
-              `vite-imagetools cannot find image with requested id "${id}"`
-            )
+            server.config.logger.warn(`vite-imagetools cannot find image with requested id "${id}"`)
 
             res.statusCode = 404
             res.setHeader('Content-Type', 'text/plain')

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -297,7 +297,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           // rather than returning a generic HTML error page.
           if (!processedImage) {
             server.config.logger.error(
-              `vite-imagetools cannot find image with id "${id}" this is likely an internal error`
+              `vite-imagetools cannot find image with requested id "${id}"`
             )
 
             res.statusCode = 404

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -296,7 +296,7 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
           // The log keeps the diagnosis, and the body says which id was missed
           // rather than returning a generic HTML error page.
           if (!processedImage) {
-            server.config.logger.error(
+            server.config.logger.warn(
               `vite-imagetools cannot find image with requested id "${id}"`
             )
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -281,20 +281,10 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           const processedImage = generatedImages.get(id)
 
-          // Respond to a miss instead of throwing. The status was already 404
-          // either way — Connect's fallback handler produces one — but a throw
-          // additionally makes Vite treat this as an *internal server error*,
+          // Respond to a miss instead of throwing. The status is 404 regardless,
+          // but a throw makes Vite treat this as an *internal server error*,
           // which in dev raises the error overlay over the whole page. That is a
-          // large consequence for one image failing to resolve, and in a browser
-          // test harness the overlay sits above the page and silently swallows
-          // clicks aimed at it.
-          //
-          // Throwing also loses the reader: the stack unwinds through middleware
-          // Vite registered earlier, so its top frames are unrelated ones such as
-          // hostValidation and cors rather than this plugin.
-          //
-          // The log keeps the diagnosis, and the body says which id was missed
-          // rather than returning a generic HTML error page.
+          // large consequence for one image failing to resolve.
           if (!processedImage) {
             server.config.logger.warn(
               `vite-imagetools cannot find image with requested id "${id}"`

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -281,8 +281,30 @@ export function imagetools(userOptions: Partial<VitePluginOptions> = {}): Plugin
 
           const processedImage = generatedImages.get(id)
 
-          if (!processedImage)
-            throw new Error(`vite-imagetools cannot find image with id "${id}" this is likely an internal error`)
+          // Respond to a miss instead of throwing. The status was already 404
+          // either way — Connect's fallback handler produces one — but a throw
+          // additionally makes Vite treat this as an *internal server error*,
+          // which in dev raises the error overlay over the whole page. That is a
+          // large consequence for one image failing to resolve, and in a browser
+          // test harness the overlay sits above the page and silently swallows
+          // clicks aimed at it.
+          //
+          // Throwing also loses the reader: the stack unwinds through middleware
+          // Vite registered earlier, so its top frames are unrelated ones such as
+          // hostValidation and cors rather than this plugin.
+          //
+          // The log keeps the diagnosis, and the body says which id was missed
+          // rather than returning a generic HTML error page.
+          if (!processedImage) {
+            server.config.logger.error(
+              `vite-imagetools cannot find image with id "${id}" this is likely an internal error`
+            )
+
+            res.statusCode = 404
+            res.setHeader('Content-Type', 'text/plain')
+            res.end(`vite-imagetools has no image with id "${id}"`)
+            return
+          }
 
           const { image } = processedImage
 


### PR DESCRIPTION
Follows up on #800 — this does not fix the missing id, only the way a miss is handled.

## The problem

`configureServer`'s middleware throws when an id isn't in `generatedImages`. The HTTP status was already 404 either way, because Connect's fallback handler produces one — so the existing middleware test passed before and after. What throwing *adds* is the damage:

- **Vite classifies it as an internal server error**, which raises the dev error overlay over the whole page. That is a large consequence for one image failing to resolve.
- **The stack misleads.** It unwinds through middleware Vite registered earlier, so the top frames are unrelated ones such as `hostValidation` and `cors` rather than this plugin. I spent a while treating those as the lead.
- **The body is a generic HTML error page** rather than anything naming the id.

Measured on `vite@7.3.1`:

| | status | body | logger |
|---|---|---|---|
| before | 404 | `<!DOCTYPE html>…<title>Error</title>` | `Internal server error: vite-imagetools cannot find image with id "…"` + stack |
| after | 404 | `vite-imagetools has no image with id "…"` | the message alone |

## How it showed up

Under Vitest browser mode the overlay is injected into the **orchestrator** document, one level above the test iframe. `userEvent` drives a real pointer at top-level coordinates, so the overlay takes the click while the element underneath never sees it — `click()` reports success and throws nothing, and `elementFromPoint` *inside* the iframe keeps returning the intended element.

Symptoms were four unrelated test files failing intermittently, roughly 1 run in 3 to 13, on assertions with no obvious common factor: a `<details>` not opening after clicking its `<summary>` (native behaviour, no listener involved), `document.activeElement` still `<body>`, a form callback never firing. Three hypotheses died before a failure screenshot showed the overlay.

A single request is enough to reproduce:

```js
await fetch('/@imagetools/deliberately-not-a-real-id')
```

## The change

Log the diagnostic, respond `404 text/plain` naming the id, and return. No behaviour depends on the throw, and the status is unchanged.

## Test

The existing `dev server serves transformed images through the middleware` test already asserted `missing.status === 404`, so it passed with the throw in place. I extended it with the two things that actually distinguish the behaviour:

```ts
expect(await missing.text()).toContain('does-not-exist')
expect(loggedErrors.join('\n')).not.toContain('Internal server error')
```

Verified load-bearing — reverting `src/index.ts` alone and keeping the test gives:

```
AssertionError: expected '…' not to contain 'Internal server error'
+ Internal server error: vite-imagetools cannot find image with id "does-not-exist" …
```

## Notes

- `pnpm --filter vite-imagetools test` on my machine (Windows) is **2 failed / 48 passed**, versus **3 failed / 47 passed** on an unmodified checkout. The remainder are pre-existing here — `absolute import` and `check "originalFilename" exported correctly` both fail on `Rolldown failed to resolve import "C:\…"`, which looks like a path issue on Windows rather than anything to do with this change. The third baseline failure, `a concurrent reader never observes a partially written file`, appears to be flaky. Worth someone confirming on Linux.
- Changeset included, patch.
- Happy to adjust the response shape — `next()` instead of ending the response, a different body, or dropping the log — if you'd prefer something else.
